### PR TITLE
Backend for Staged jobs

### DIFF
--- a/ent/credential/credential.go
+++ b/ent/credential/credential.go
@@ -33,13 +33,18 @@ const (
 	TargetColumn = "target_id"
 )
 
-// Columns holds all SQL columns are credential fields.
+// Columns holds all SQL columns for credential fields.
 var Columns = []string{
 	FieldID,
 	FieldPrincipal,
 	FieldSecret,
 	FieldKind,
 	FieldFails,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the Credential type.
+var ForeignKeys = []string{
+	"target_id",
 }
 
 var (
@@ -61,6 +66,7 @@ var (
 // Kind defines the type for the kind enum field.
 type Kind string
 
+// Kind values.
 const (
 	KindPassword    Kind = "password"
 	KindKey         Kind = "key"
@@ -71,12 +77,12 @@ func (s Kind) String() string {
 	return string(s)
 }
 
-// KindValidator is a validator for the "kind" field enum values. It is called by the builders before save.
-func KindValidator(kind Kind) error {
-	switch kind {
+// KindValidator is a validator for the "k" field enum values. It is called by the builders before save.
+func KindValidator(k Kind) error {
+	switch k {
 	case KindPassword, KindKey, KindCertificate:
 		return nil
 	default:
-		return fmt.Errorf("credential: invalid enum value for kind field: %q", kind)
+		return fmt.Errorf("credential: invalid enum value for kind field: %q", k)
 	}
 }

--- a/ent/credential_create.go
+++ b/ent/credential_create.go
@@ -118,8 +118,8 @@ func (cc *CredentialCreate) SaveX(ctx context.Context) *Credential {
 
 func (cc *CredentialCreate) sqlSave(ctx context.Context) (*Credential, error) {
 	var (
-		c    = &Credential{config: cc.config}
-		spec = &sqlgraph.CreateSpec{
+		c     = &Credential{config: cc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: credential.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -128,7 +128,7 @@ func (cc *CredentialCreate) sqlSave(ctx context.Context) (*Credential, error) {
 		}
 	)
 	if value := cc.principal; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: credential.FieldPrincipal,
@@ -136,7 +136,7 @@ func (cc *CredentialCreate) sqlSave(ctx context.Context) (*Credential, error) {
 		c.Principal = *value
 	}
 	if value := cc.secret; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: credential.FieldSecret,
@@ -144,7 +144,7 @@ func (cc *CredentialCreate) sqlSave(ctx context.Context) (*Credential, error) {
 		c.Secret = *value
 	}
 	if value := cc.kind; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeEnum,
 			Value:  *value,
 			Column: credential.FieldKind,
@@ -152,7 +152,7 @@ func (cc *CredentialCreate) sqlSave(ctx context.Context) (*Credential, error) {
 		c.Kind = *value
 	}
 	if value := cc.fails; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: credential.FieldFails,
@@ -176,15 +176,15 @@ func (cc *CredentialCreate) sqlSave(ctx context.Context) (*Credential, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, cc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, cc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	c.ID = int(id)
 	return c, nil
 }

--- a/ent/credential_delete.go
+++ b/ent/credential_delete.go
@@ -39,7 +39,7 @@ func (cd *CredentialDelete) ExecX(ctx context.Context) int {
 }
 
 func (cd *CredentialDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: credential.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (cd *CredentialDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := cd.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, cd.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, cd.driver, _spec)
 }
 
 // CredentialDeleteOne is the builder for deleting a single Credential entity.

--- a/ent/credential_update.go
+++ b/ent/credential_update.go
@@ -151,7 +151,7 @@ func (cu *CredentialUpdate) ExecX(ctx context.Context) {
 }
 
 func (cu *CredentialUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   credential.Table,
 			Columns: credential.Columns,
@@ -162,42 +162,42 @@ func (cu *CredentialUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := cu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := cu.principal; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: credential.FieldPrincipal,
 		})
 	}
 	if value := cu.secret; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: credential.FieldSecret,
 		})
 	}
 	if value := cu.kind; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeEnum,
 			Value:  *value,
 			Column: credential.FieldKind,
 		})
 	}
 	if value := cu.fails; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: credential.FieldFails,
 		})
 	}
 	if value := cu.addfails; value != nil {
-		spec.Fields.Add = append(spec.Fields.Add, &sqlgraph.FieldSpec{
+		_spec.Fields.Add = append(_spec.Fields.Add, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: credential.FieldFails,
@@ -217,7 +217,7 @@ func (cu *CredentialUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := cu.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -236,9 +236,9 @@ func (cu *CredentialUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, cu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, cu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -377,7 +377,7 @@ func (cuo *CredentialUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (cuo *CredentialUpdateOne) sqlSave(ctx context.Context) (c *Credential, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   credential.Table,
 			Columns: credential.Columns,
@@ -389,35 +389,35 @@ func (cuo *CredentialUpdateOne) sqlSave(ctx context.Context) (c *Credential, err
 		},
 	}
 	if value := cuo.principal; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: credential.FieldPrincipal,
 		})
 	}
 	if value := cuo.secret; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: credential.FieldSecret,
 		})
 	}
 	if value := cuo.kind; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeEnum,
 			Value:  *value,
 			Column: credential.FieldKind,
 		})
 	}
 	if value := cuo.fails; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: credential.FieldFails,
 		})
 	}
 	if value := cuo.addfails; value != nil {
-		spec.Fields.Add = append(spec.Fields.Add, &sqlgraph.FieldSpec{
+		_spec.Fields.Add = append(_spec.Fields.Add, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: credential.FieldFails,
@@ -437,7 +437,7 @@ func (cuo *CredentialUpdateOne) sqlSave(ctx context.Context) (c *Credential, err
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := cuo.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -456,12 +456,12 @@ func (cuo *CredentialUpdateOne) sqlSave(ctx context.Context) (c *Credential, err
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	c = &Credential{config: cuo.config}
-	spec.Assign = c.assignValues
-	spec.ScanValues = c.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, cuo.driver, spec); err != nil {
+	_spec.Assign = c.assignValues
+	_spec.ScanValues = c.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, cuo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/event.go
+++ b/ent/event.go
@@ -20,21 +20,81 @@ type Event struct {
 	CreationTime time.Time `json:"CreationTime,omitempty"`
 	// Kind holds the value of the "Kind" field.
 	Kind event.Kind `json:"Kind,omitempty"`
+	// Edges holds the relations/edges for other nodes in the graph.
+	// The values are being populated by the EventQuery when eager-loading is set.
+	Edges struct {
+		// Job holds the value of the job edge.
+		Job *Job
+		// File holds the value of the file edge.
+		File *File
+		// Credential holds the value of the credential edge.
+		Credential *Credential
+		// Link holds the value of the link edge.
+		Link *Link
+		// Tag holds the value of the tag edge.
+		Tag *Tag
+		// Target holds the value of the target edge.
+		Target *Target
+		// Task holds the value of the task edge.
+		Task *Task
+		// User holds the value of the user edge.
+		User *User
+		// Event holds the value of the event edge.
+		Event *Event
+		// Service holds the value of the service edge.
+		Service *Service
+		// Likers holds the value of the likers edge.
+		Likers []*User
+		// Owner holds the value of the owner edge.
+		Owner *User
+		// SvcOwner holds the value of the svcOwner edge.
+		SvcOwner *Service
+	} `json:"edges"`
+	event_job_id        *int
+	event_file_id       *int
+	event_credential_id *int
+	event_link_id       *int
+	event_tag_id        *int
+	event_target_id     *int
+	event_task_id       *int
+	event_user_id       *int
+	event_event_id      *int
+	event_service_id    *int
+	svc_owner_id        *int
+	owner_id            *int
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
 func (*Event) scanValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{},
-		&sql.NullTime{},
-		&sql.NullString{},
+		&sql.NullInt64{},  // id
+		&sql.NullTime{},   // CreationTime
+		&sql.NullString{}, // Kind
+	}
+}
+
+// fkValues returns the types for scanning foreign-keys values from sql.Rows.
+func (*Event) fkValues() []interface{} {
+	return []interface{}{
+		&sql.NullInt64{}, // event_job_id
+		&sql.NullInt64{}, // event_file_id
+		&sql.NullInt64{}, // event_credential_id
+		&sql.NullInt64{}, // event_link_id
+		&sql.NullInt64{}, // event_tag_id
+		&sql.NullInt64{}, // event_target_id
+		&sql.NullInt64{}, // event_task_id
+		&sql.NullInt64{}, // event_user_id
+		&sql.NullInt64{}, // event_event_id
+		&sql.NullInt64{}, // event_service_id
+		&sql.NullInt64{}, // svc_owner_id
+		&sql.NullInt64{}, // owner_id
 	}
 }
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the Event fields.
 func (e *Event) assignValues(values ...interface{}) error {
-	if m, n := len(values), len(event.Columns); m != n {
+	if m, n := len(values), len(event.Columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
 	value, ok := values[0].(*sql.NullInt64)
@@ -52,6 +112,81 @@ func (e *Event) assignValues(values ...interface{}) error {
 		return fmt.Errorf("unexpected type %T for field Kind", values[1])
 	} else if value.Valid {
 		e.Kind = event.Kind(value.String)
+	}
+	values = values[2:]
+	if len(values) == len(event.ForeignKeys) {
+		if value, ok := values[0].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_job_id", value)
+		} else if value.Valid {
+			e.event_job_id = new(int)
+			*e.event_job_id = int(value.Int64)
+		}
+		if value, ok := values[1].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_file_id", value)
+		} else if value.Valid {
+			e.event_file_id = new(int)
+			*e.event_file_id = int(value.Int64)
+		}
+		if value, ok := values[2].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_credential_id", value)
+		} else if value.Valid {
+			e.event_credential_id = new(int)
+			*e.event_credential_id = int(value.Int64)
+		}
+		if value, ok := values[3].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_link_id", value)
+		} else if value.Valid {
+			e.event_link_id = new(int)
+			*e.event_link_id = int(value.Int64)
+		}
+		if value, ok := values[4].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_tag_id", value)
+		} else if value.Valid {
+			e.event_tag_id = new(int)
+			*e.event_tag_id = int(value.Int64)
+		}
+		if value, ok := values[5].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_target_id", value)
+		} else if value.Valid {
+			e.event_target_id = new(int)
+			*e.event_target_id = int(value.Int64)
+		}
+		if value, ok := values[6].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_task_id", value)
+		} else if value.Valid {
+			e.event_task_id = new(int)
+			*e.event_task_id = int(value.Int64)
+		}
+		if value, ok := values[7].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_user_id", value)
+		} else if value.Valid {
+			e.event_user_id = new(int)
+			*e.event_user_id = int(value.Int64)
+		}
+		if value, ok := values[8].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_event_id", value)
+		} else if value.Valid {
+			e.event_event_id = new(int)
+			*e.event_event_id = int(value.Int64)
+		}
+		if value, ok := values[9].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_service_id", value)
+		} else if value.Valid {
+			e.event_service_id = new(int)
+			*e.event_service_id = int(value.Int64)
+		}
+		if value, ok := values[10].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field svc_owner_id", value)
+		} else if value.Valid {
+			e.svc_owner_id = new(int)
+			*e.svc_owner_id = int(value.Int64)
+		}
+		if value, ok := values[11].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field owner_id", value)
+		} else if value.Valid {
+			e.owner_id = new(int)
+			*e.owner_id = int(value.Int64)
+		}
 	}
 	return nil
 }

--- a/ent/event/event.go
+++ b/ent/event/event.go
@@ -111,11 +111,27 @@ const (
 	SvcOwnerColumn = "svc_owner_id"
 )
 
-// Columns holds all SQL columns are event fields.
+// Columns holds all SQL columns for event fields.
 var Columns = []string{
 	FieldID,
 	FieldCreationTime,
 	FieldKind,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the Event type.
+var ForeignKeys = []string{
+	"event_job_id",
+	"event_file_id",
+	"event_credential_id",
+	"event_link_id",
+	"event_tag_id",
+	"event_target_id",
+	"event_task_id",
+	"event_user_id",
+	"event_event_id",
+	"event_service_id",
+	"svc_owner_id",
+	"owner_id",
 }
 
 var (
@@ -130,6 +146,7 @@ var (
 // Kind defines the type for the Kind enum field.
 type Kind string
 
+// Kind values.
 const (
 	KindCREATEJOB              Kind = "CREATE_JOB"
 	KindCREATETAG              Kind = "CREATE_TAG"
@@ -161,12 +178,12 @@ func (s Kind) String() string {
 	return string(s)
 }
 
-// KindValidator is a validator for the "Kind" field enum values. It is called by the builders before save.
-func KindValidator(Kind Kind) error {
-	switch Kind {
+// KindValidator is a validator for the "k" field enum values. It is called by the builders before save.
+func KindValidator(k Kind) error {
+	switch k {
 	case KindCREATEJOB, KindCREATETAG, KindAPPLYTAGTOTASK, KindAPPLYTAGTOTARGET, KindAPPLYTAGTOJOB, KindREMOVETAGFROMTASK, KindREMOVETAGFROMTARGET, KindREMOVETAGFROMJOB, KindCREATETARGET, KindSETTARGETFIELDS, KindDELETETARGET, KindADDCREDENTIALFORTARGET, KindUPLOADFILE, KindCREATELINK, KindSETLINKFIELDS, KindACTIVATEUSER, KindCREATEUSER, KindMAKEADMIN, KindREMOVEADMIN, KindCHANGENAME, KindACTIVATESERVICE, KindCREATESERVICE, KindLIKEEVENT, KindOTHER:
 		return nil
 	default:
-		return fmt.Errorf("event: invalid enum value for Kind field: %q", Kind)
+		return fmt.Errorf("event: invalid enum value for Kind field: %q", k)
 	}
 }

--- a/ent/event_create.go
+++ b/ent/event_create.go
@@ -408,8 +408,8 @@ func (ec *EventCreate) SaveX(ctx context.Context) *Event {
 
 func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 	var (
-		e    = &Event{config: ec.config}
-		spec = &sqlgraph.CreateSpec{
+		e     = &Event{config: ec.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: event.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -418,7 +418,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		}
 	)
 	if value := ec.CreationTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: event.FieldCreationTime,
@@ -426,7 +426,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		e.CreationTime = *value
 	}
 	if value := ec.Kind; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeEnum,
 			Value:  *value,
 			Column: event.FieldKind,
@@ -450,7 +450,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.file; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -469,7 +469,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.credential; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -488,7 +488,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.link; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -507,7 +507,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.tag; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -526,7 +526,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -545,7 +545,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.task; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -564,7 +564,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.user; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -583,7 +583,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.event; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -602,7 +602,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.service; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -621,7 +621,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.likers; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -640,7 +640,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.owner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -659,7 +659,7 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := ec.svcOwner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -678,15 +678,15 @@ func (ec *EventCreate) sqlSave(ctx context.Context) (*Event, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, ec.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, ec.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	e.ID = int(id)
 	return e, nil
 }

--- a/ent/event_delete.go
+++ b/ent/event_delete.go
@@ -39,7 +39,7 @@ func (ed *EventDelete) ExecX(ctx context.Context) int {
 }
 
 func (ed *EventDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: event.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (ed *EventDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := ed.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, ed.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, ed.driver, _spec)
 }
 
 // EventDeleteOne is the builder for deleting a single Event entity.

--- a/ent/event_query.go
+++ b/ent/event_query.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"math"
@@ -32,6 +33,21 @@ type EventQuery struct {
 	order      []Order
 	unique     []string
 	predicates []predicate.Event
+	// eager-loading edges.
+	withJob        *JobQuery
+	withFile       *FileQuery
+	withCredential *CredentialQuery
+	withLink       *LinkQuery
+	withTag        *TagQuery
+	withTarget     *TargetQuery
+	withTask       *TaskQuery
+	withUser       *UserQuery
+	withEvent      *EventQuery
+	withService    *ServiceQuery
+	withLikers     *UserQuery
+	withOwner      *UserQuery
+	withSvcOwner   *ServiceQuery
+	withFKs        bool
 	// intermediate query.
 	sql *sql.Selector
 }
@@ -385,6 +401,149 @@ func (eq *EventQuery) Clone() *EventQuery {
 	}
 }
 
+//  WithJob tells the query-builder to eager-loads the nodes that are connected to
+// the "job" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithJob(opts ...func(*JobQuery)) *EventQuery {
+	query := &JobQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withJob = query
+	return eq
+}
+
+//  WithFile tells the query-builder to eager-loads the nodes that are connected to
+// the "file" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithFile(opts ...func(*FileQuery)) *EventQuery {
+	query := &FileQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withFile = query
+	return eq
+}
+
+//  WithCredential tells the query-builder to eager-loads the nodes that are connected to
+// the "credential" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithCredential(opts ...func(*CredentialQuery)) *EventQuery {
+	query := &CredentialQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withCredential = query
+	return eq
+}
+
+//  WithLink tells the query-builder to eager-loads the nodes that are connected to
+// the "link" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithLink(opts ...func(*LinkQuery)) *EventQuery {
+	query := &LinkQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withLink = query
+	return eq
+}
+
+//  WithTag tells the query-builder to eager-loads the nodes that are connected to
+// the "tag" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithTag(opts ...func(*TagQuery)) *EventQuery {
+	query := &TagQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withTag = query
+	return eq
+}
+
+//  WithTarget tells the query-builder to eager-loads the nodes that are connected to
+// the "target" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithTarget(opts ...func(*TargetQuery)) *EventQuery {
+	query := &TargetQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withTarget = query
+	return eq
+}
+
+//  WithTask tells the query-builder to eager-loads the nodes that are connected to
+// the "task" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithTask(opts ...func(*TaskQuery)) *EventQuery {
+	query := &TaskQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withTask = query
+	return eq
+}
+
+//  WithUser tells the query-builder to eager-loads the nodes that are connected to
+// the "user" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithUser(opts ...func(*UserQuery)) *EventQuery {
+	query := &UserQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withUser = query
+	return eq
+}
+
+//  WithEvent tells the query-builder to eager-loads the nodes that are connected to
+// the "event" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithEvent(opts ...func(*EventQuery)) *EventQuery {
+	query := &EventQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withEvent = query
+	return eq
+}
+
+//  WithService tells the query-builder to eager-loads the nodes that are connected to
+// the "service" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithService(opts ...func(*ServiceQuery)) *EventQuery {
+	query := &ServiceQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withService = query
+	return eq
+}
+
+//  WithLikers tells the query-builder to eager-loads the nodes that are connected to
+// the "likers" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithLikers(opts ...func(*UserQuery)) *EventQuery {
+	query := &UserQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withLikers = query
+	return eq
+}
+
+//  WithOwner tells the query-builder to eager-loads the nodes that are connected to
+// the "owner" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithOwner(opts ...func(*UserQuery)) *EventQuery {
+	query := &UserQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withOwner = query
+	return eq
+}
+
+//  WithSvcOwner tells the query-builder to eager-loads the nodes that are connected to
+// the "svcOwner" edge. The optional arguments used to configure the query builder of the edge.
+func (eq *EventQuery) WithSvcOwner(opts ...func(*ServiceQuery)) *EventQuery {
+	query := &ServiceQuery{config: eq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	eq.withSvcOwner = query
+	return eq
+}
+
 // GroupBy used to group vertices by one or more fields/columns.
 // It is often used with aggregate functions, like: count, max, mean, min, sum.
 //
@@ -428,30 +587,374 @@ func (eq *EventQuery) Select(field string, fields ...string) *EventSelect {
 
 func (eq *EventQuery) sqlAll(ctx context.Context) ([]*Event, error) {
 	var (
-		nodes []*Event
-		spec  = eq.querySpec()
+		nodes   []*Event
+		withFKs = eq.withFKs
+		_spec   = eq.querySpec()
 	)
-	spec.ScanValues = func() []interface{} {
+	if eq.withJob != nil || eq.withFile != nil || eq.withCredential != nil || eq.withLink != nil || eq.withTag != nil || eq.withTarget != nil || eq.withTask != nil || eq.withUser != nil || eq.withEvent != nil || eq.withService != nil || eq.withOwner != nil || eq.withSvcOwner != nil {
+		withFKs = true
+	}
+	if withFKs {
+		_spec.Node.Columns = append(_spec.Node.Columns, event.ForeignKeys...)
+	}
+	_spec.ScanValues = func() []interface{} {
 		node := &Event{config: eq.config}
 		nodes = append(nodes, node)
-		return node.scanValues()
+		values := node.scanValues()
+		if withFKs {
+			values = append(values, node.fkValues()...)
+		}
+		return values
 	}
-	spec.Assign = func(values ...interface{}) error {
+	_spec.Assign = func(values ...interface{}) error {
 		if len(nodes) == 0 {
 			return fmt.Errorf("ent: Assign called without calling ScanValues")
 		}
 		node := nodes[len(nodes)-1]
 		return node.assignValues(values...)
 	}
-	if err := sqlgraph.QueryNodes(ctx, eq.driver, spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, eq.driver, _spec); err != nil {
 		return nil, err
 	}
+
+	if len(nodes) == 0 {
+		return nodes, nil
+	}
+
+	if query := eq.withJob; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_job_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(job.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_job_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Job = n
+			}
+		}
+	}
+
+	if query := eq.withFile; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_file_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(file.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_file_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.File = n
+			}
+		}
+	}
+
+	if query := eq.withCredential; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_credential_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(credential.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_credential_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Credential = n
+			}
+		}
+	}
+
+	if query := eq.withLink; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_link_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(link.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_link_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Link = n
+			}
+		}
+	}
+
+	if query := eq.withTag; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_tag_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(tag.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_tag_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Tag = n
+			}
+		}
+	}
+
+	if query := eq.withTarget; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_target_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(target.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_target_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Target = n
+			}
+		}
+	}
+
+	if query := eq.withTask; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_task_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(task.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_task_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Task = n
+			}
+		}
+	}
+
+	if query := eq.withUser; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_user_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(user.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_user_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.User = n
+			}
+		}
+	}
+
+	if query := eq.withEvent; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_event_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(event.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_event_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Event = n
+			}
+		}
+	}
+
+	if query := eq.withService; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].event_service_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(service.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_service_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Service = n
+			}
+		}
+	}
+
+	if query := eq.withLikers; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		nodeids := make(map[int]*Event)
+		for i := range nodes {
+			fks = append(fks, nodes[i].ID)
+			nodeids[nodes[i].ID] = nodes[i]
+		}
+		query.withFKs = true
+		query.Where(predicate.User(func(s *sql.Selector) {
+			s.Where(sql.InValues(event.LikersColumn, fks...))
+		}))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			fk := n.event_liker_id
+			if fk == nil {
+				return nil, fmt.Errorf(`foreign-key "event_liker_id" is nil for node %v`, n.ID)
+			}
+			node, ok := nodeids[*fk]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "event_liker_id" returned %v for node %v`, *fk, n.ID)
+			}
+			node.Edges.Likers = append(node.Edges.Likers, n)
+		}
+	}
+
+	if query := eq.withOwner; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].owner_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(user.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Owner = n
+			}
+		}
+	}
+
+	if query := eq.withSvcOwner; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Event)
+		for i := range nodes {
+			if fk := nodes[i].svc_owner_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(service.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "svc_owner_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.SvcOwner = n
+			}
+		}
+	}
+
 	return nodes, nil
 }
 
 func (eq *EventQuery) sqlCount(ctx context.Context) (int, error) {
-	spec := eq.querySpec()
-	return sqlgraph.CountNodes(ctx, eq.driver, spec)
+	_spec := eq.querySpec()
+	return sqlgraph.CountNodes(ctx, eq.driver, _spec)
 }
 
 func (eq *EventQuery) sqlExist(ctx context.Context) (bool, error) {
@@ -463,7 +966,7 @@ func (eq *EventQuery) sqlExist(ctx context.Context) (bool, error) {
 }
 
 func (eq *EventQuery) querySpec() *sqlgraph.QuerySpec {
-	spec := &sqlgraph.QuerySpec{
+	_spec := &sqlgraph.QuerySpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   event.Table,
 			Columns: event.Columns,
@@ -476,26 +979,26 @@ func (eq *EventQuery) querySpec() *sqlgraph.QuerySpec {
 		Unique: true,
 	}
 	if ps := eq.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if limit := eq.limit; limit != nil {
-		spec.Limit = *limit
+		_spec.Limit = *limit
 	}
 	if offset := eq.offset; offset != nil {
-		spec.Offset = *offset
+		_spec.Offset = *offset
 	}
 	if ps := eq.order; len(ps) > 0 {
-		spec.Order = func(selector *sql.Selector) {
+		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return spec
+	return _spec
 }
 
 func (eq *EventQuery) sqlQuery() *sql.Selector {

--- a/ent/event_update.go
+++ b/ent/event_update.go
@@ -529,7 +529,7 @@ func (eu *EventUpdate) ExecX(ctx context.Context) {
 }
 
 func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   event.Table,
 			Columns: event.Columns,
@@ -540,21 +540,21 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := eu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := eu.CreationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: event.FieldCreationTime,
 		})
 	}
 	if value := eu.Kind; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeEnum,
 			Value:  *value,
 			Column: event.FieldKind,
@@ -574,7 +574,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.job; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -593,7 +593,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedFile {
 		edge := &sqlgraph.EdgeSpec{
@@ -609,7 +609,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.file; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -628,7 +628,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedCredential {
 		edge := &sqlgraph.EdgeSpec{
@@ -644,7 +644,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.credential; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -663,7 +663,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedLink {
 		edge := &sqlgraph.EdgeSpec{
@@ -679,7 +679,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.link; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -698,7 +698,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedTag {
 		edge := &sqlgraph.EdgeSpec{
@@ -714,7 +714,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.tag; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -733,7 +733,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedTarget {
 		edge := &sqlgraph.EdgeSpec{
@@ -749,7 +749,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -768,7 +768,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedTask {
 		edge := &sqlgraph.EdgeSpec{
@@ -784,7 +784,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.task; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -803,7 +803,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedUser {
 		edge := &sqlgraph.EdgeSpec{
@@ -819,7 +819,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.user; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -838,7 +838,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedEvent {
 		edge := &sqlgraph.EdgeSpec{
@@ -854,7 +854,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.event; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -873,7 +873,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedService {
 		edge := &sqlgraph.EdgeSpec{
@@ -889,7 +889,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.service; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -908,7 +908,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := eu.removedLikers; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -927,7 +927,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.likers; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -946,7 +946,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedOwner {
 		edge := &sqlgraph.EdgeSpec{
@@ -962,7 +962,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.owner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -981,7 +981,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if eu.clearedSvcOwner {
 		edge := &sqlgraph.EdgeSpec{
@@ -997,7 +997,7 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := eu.svcOwner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1016,9 +1016,9 @@ func (eu *EventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, eu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, eu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -1526,7 +1526,7 @@ func (euo *EventUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   event.Table,
 			Columns: event.Columns,
@@ -1538,14 +1538,14 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		},
 	}
 	if value := euo.CreationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: event.FieldCreationTime,
 		})
 	}
 	if value := euo.Kind; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeEnum,
 			Value:  *value,
 			Column: event.FieldKind,
@@ -1565,7 +1565,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.job; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1584,7 +1584,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedFile {
 		edge := &sqlgraph.EdgeSpec{
@@ -1600,7 +1600,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.file; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1619,7 +1619,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedCredential {
 		edge := &sqlgraph.EdgeSpec{
@@ -1635,7 +1635,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.credential; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1654,7 +1654,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedLink {
 		edge := &sqlgraph.EdgeSpec{
@@ -1670,7 +1670,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.link; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1689,7 +1689,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedTag {
 		edge := &sqlgraph.EdgeSpec{
@@ -1705,7 +1705,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.tag; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1724,7 +1724,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedTarget {
 		edge := &sqlgraph.EdgeSpec{
@@ -1740,7 +1740,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1759,7 +1759,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedTask {
 		edge := &sqlgraph.EdgeSpec{
@@ -1775,7 +1775,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.task; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1794,7 +1794,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedUser {
 		edge := &sqlgraph.EdgeSpec{
@@ -1810,7 +1810,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.user; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1829,7 +1829,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedEvent {
 		edge := &sqlgraph.EdgeSpec{
@@ -1845,7 +1845,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.event; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1864,7 +1864,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedService {
 		edge := &sqlgraph.EdgeSpec{
@@ -1880,7 +1880,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.service; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1899,7 +1899,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := euo.removedLikers; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1918,7 +1918,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.likers; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1937,7 +1937,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedOwner {
 		edge := &sqlgraph.EdgeSpec{
@@ -1953,7 +1953,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.owner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1972,7 +1972,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if euo.clearedSvcOwner {
 		edge := &sqlgraph.EdgeSpec{
@@ -1988,7 +1988,7 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := euo.svcOwner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -2007,12 +2007,12 @@ func (euo *EventUpdateOne) sqlSave(ctx context.Context) (e *Event, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	e = &Event{config: euo.config}
-	spec.Assign = e.assignValues
-	spec.ScanValues = e.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, euo.driver, spec); err != nil {
+	_spec.Assign = e.assignValues
+	_spec.ScanValues = e.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, euo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/example_test.go
+++ b/ent/example_test.go
@@ -63,6 +63,7 @@ func ExampleEvent() {
 		SetName("string").
 		SetCreationTime(time.Now()).
 		SetContent("string").
+		SetStaged(true).
 		SaveX(ctx)
 	log.Println("job created:", j0)
 	f1 := client.File.
@@ -320,6 +321,7 @@ func ExampleJob() {
 		SetName("string").
 		SetCreationTime(time.Now()).
 		SetContent("string").
+		SetStaged(true).
 		SaveX(ctx)
 	log.Println("job created:", j3)
 
@@ -329,6 +331,7 @@ func ExampleJob() {
 		SetName("string").
 		SetCreationTime(time.Now()).
 		SetContent("string").
+		SetStaged(true).
 		AddTasks(t0).
 		AddTags(t1).
 		SetNext(j3).
@@ -592,6 +595,7 @@ func ExampleUser() {
 		SetName("string").
 		SetCreationTime(time.Now()).
 		SetContent("string").
+		SetStaged(true).
 		SaveX(ctx)
 	log.Println("job created:", j0)
 	e1 := client.Event.

--- a/ent/file.go
+++ b/ent/file.go
@@ -30,26 +30,32 @@ type File struct {
 	Hash string `json:"Hash,omitempty"`
 	// ContentType holds the value of the "ContentType" field.
 	ContentType string `json:"ContentType,omitempty"`
+	// Edges holds the relations/edges for other nodes in the graph.
+	// The values are being populated by the FileQuery when eager-loading is set.
+	Edges struct {
+		// Links holds the value of the links edge.
+		Links []*Link
+	} `json:"edges"`
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
 func (*File) scanValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{},
-		&sql.NullString{},
-		&sql.NullTime{},
-		&sql.NullTime{},
-		&sql.NullInt64{},
-		&[]byte{},
-		&sql.NullString{},
-		&sql.NullString{},
+		&sql.NullInt64{},  // id
+		&sql.NullString{}, // Name
+		&sql.NullTime{},   // CreationTime
+		&sql.NullTime{},   // LastModifiedTime
+		&sql.NullInt64{},  // Size
+		&[]byte{},         // Content
+		&sql.NullString{}, // Hash
+		&sql.NullString{}, // ContentType
 	}
 }
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the File fields.
 func (f *File) assignValues(values ...interface{}) error {
-	if m, n := len(values), len(file.Columns); m != n {
+	if m, n := len(values), len(file.Columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
 	value, ok := values[0].(*sql.NullInt64)

--- a/ent/file/file.go
+++ b/ent/file/file.go
@@ -39,7 +39,7 @@ const (
 	LinksColumn = "file_id"
 )
 
-// Columns holds all SQL columns are file fields.
+// Columns holds all SQL columns for file fields.
 var Columns = []string{
 	FieldID,
 	FieldName,

--- a/ent/file_create.go
+++ b/ent/file_create.go
@@ -153,8 +153,8 @@ func (fc *FileCreate) SaveX(ctx context.Context) *File {
 
 func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 	var (
-		f    = &File{config: fc.config}
-		spec = &sqlgraph.CreateSpec{
+		f     = &File{config: fc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: file.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -163,7 +163,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		}
 	)
 	if value := fc.Name; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldName,
@@ -171,7 +171,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		f.Name = *value
 	}
 	if value := fc.CreationTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: file.FieldCreationTime,
@@ -179,7 +179,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		f.CreationTime = *value
 	}
 	if value := fc.LastModifiedTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: file.FieldLastModifiedTime,
@@ -187,7 +187,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		f.LastModifiedTime = *value
 	}
 	if value := fc.Size; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: file.FieldSize,
@@ -195,7 +195,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		f.Size = *value
 	}
 	if value := fc.Content; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeBytes,
 			Value:  *value,
 			Column: file.FieldContent,
@@ -203,7 +203,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		f.Content = *value
 	}
 	if value := fc.Hash; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldHash,
@@ -211,7 +211,7 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		f.Hash = *value
 	}
 	if value := fc.ContentType; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldContentType,
@@ -235,15 +235,15 @@ func (fc *FileCreate) sqlSave(ctx context.Context) (*File, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, fc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, fc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	f.ID = int(id)
 	return f, nil
 }

--- a/ent/file_delete.go
+++ b/ent/file_delete.go
@@ -39,7 +39,7 @@ func (fd *FileDelete) ExecX(ctx context.Context) int {
 }
 
 func (fd *FileDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: file.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (fd *FileDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := fd.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, fd.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, fd.driver, _spec)
 }
 
 // FileDeleteOne is the builder for deleting a single File entity.

--- a/ent/file_update.go
+++ b/ent/file_update.go
@@ -189,7 +189,7 @@ func (fu *FileUpdate) ExecX(ctx context.Context) {
 }
 
 func (fu *FileUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   file.Table,
 			Columns: file.Columns,
@@ -200,63 +200,63 @@ func (fu *FileUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := fu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := fu.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldName,
 		})
 	}
 	if value := fu.CreationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: file.FieldCreationTime,
 		})
 	}
 	if value := fu.LastModifiedTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: file.FieldLastModifiedTime,
 		})
 	}
 	if value := fu.Size; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: file.FieldSize,
 		})
 	}
 	if value := fu.addSize; value != nil {
-		spec.Fields.Add = append(spec.Fields.Add, &sqlgraph.FieldSpec{
+		_spec.Fields.Add = append(_spec.Fields.Add, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: file.FieldSize,
 		})
 	}
 	if value := fu.Content; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBytes,
 			Value:  *value,
 			Column: file.FieldContent,
 		})
 	}
 	if value := fu.Hash; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldHash,
 		})
 	}
 	if value := fu.ContentType; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldContentType,
@@ -279,7 +279,7 @@ func (fu *FileUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := fu.links; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -298,9 +298,9 @@ func (fu *FileUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, fu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, fu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -477,7 +477,7 @@ func (fuo *FileUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (fuo *FileUpdateOne) sqlSave(ctx context.Context) (f *File, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   file.Table,
 			Columns: file.Columns,
@@ -489,56 +489,56 @@ func (fuo *FileUpdateOne) sqlSave(ctx context.Context) (f *File, err error) {
 		},
 	}
 	if value := fuo.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldName,
 		})
 	}
 	if value := fuo.CreationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: file.FieldCreationTime,
 		})
 	}
 	if value := fuo.LastModifiedTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: file.FieldLastModifiedTime,
 		})
 	}
 	if value := fuo.Size; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: file.FieldSize,
 		})
 	}
 	if value := fuo.addSize; value != nil {
-		spec.Fields.Add = append(spec.Fields.Add, &sqlgraph.FieldSpec{
+		_spec.Fields.Add = append(_spec.Fields.Add, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: file.FieldSize,
 		})
 	}
 	if value := fuo.Content; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBytes,
 			Value:  *value,
 			Column: file.FieldContent,
 		})
 	}
 	if value := fuo.Hash; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldHash,
 		})
 	}
 	if value := fuo.ContentType; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: file.FieldContentType,
@@ -561,7 +561,7 @@ func (fuo *FileUpdateOne) sqlSave(ctx context.Context) (f *File, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := fuo.links; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -580,12 +580,12 @@ func (fuo *FileUpdateOne) sqlSave(ctx context.Context) (f *File, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	f = &File{config: fuo.config}
-	spec.Assign = f.assignValues
-	spec.ScanValues = f.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, fuo.driver, spec); err != nil {
+	_spec.Assign = f.assignValues
+	_spec.ScanValues = f.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, fuo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/job/job.go
+++ b/ent/job/job.go
@@ -91,9 +91,4 @@ var (
 	descContent = fields[2].Descriptor()
 	// ContentValidator is a validator for the "Content" field. It is called by the builders before save.
 	ContentValidator = descContent.Validators[0].(func(string) error)
-
-	// descStaged is the schema descriptor for Staged field.
-	descStaged = fields[3].Descriptor()
-	// DefaultStaged holds the default value on creation for the Staged field.
-	DefaultStaged = descStaged.Default.(bool)
 )

--- a/ent/job/job.go
+++ b/ent/job/job.go
@@ -19,6 +19,8 @@ const (
 	FieldCreationTime = "creation_time"
 	// FieldContent holds the string denoting the content vertex property in the database.
 	FieldContent = "content"
+	// FieldStaged holds the string denoting the staged vertex property in the database.
+	FieldStaged = "staged"
 
 	// Table holds the table name of the job in the database.
 	Table = "jobs"
@@ -51,12 +53,19 @@ const (
 	OwnerColumn = "owner_id"
 )
 
-// Columns holds all SQL columns are job fields.
+// Columns holds all SQL columns for job fields.
 var Columns = []string{
 	FieldID,
 	FieldName,
 	FieldCreationTime,
 	FieldContent,
+	FieldStaged,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the Job type.
+var ForeignKeys = []string{
+	"prev_id",
+	"owner_id",
 }
 
 var (
@@ -82,4 +91,9 @@ var (
 	descContent = fields[2].Descriptor()
 	// ContentValidator is a validator for the "Content" field. It is called by the builders before save.
 	ContentValidator = descContent.Validators[0].(func(string) error)
+
+	// descStaged is the schema descriptor for Staged field.
+	descStaged = fields[3].Descriptor()
+	// DefaultStaged holds the default value on creation for the Staged field.
+	DefaultStaged = descStaged.Default.(bool)
 )

--- a/ent/job/where.go
+++ b/ent/job/where.go
@@ -127,6 +127,14 @@ func Content(v string) predicate.Job {
 	)
 }
 
+// Staged applies equality check predicate on the "Staged" field. It's identical to StagedEQ.
+func Staged(v bool) predicate.Job {
+	return predicate.Job(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldStaged), v))
+	},
+	)
+}
+
 // NameEQ applies the EQ predicate on the "Name" field.
 func NameEQ(v string) predicate.Job {
 	return predicate.Job(func(s *sql.Selector) {
@@ -455,6 +463,22 @@ func ContentEqualFold(v string) predicate.Job {
 func ContentContainsFold(v string) predicate.Job {
 	return predicate.Job(func(s *sql.Selector) {
 		s.Where(sql.ContainsFold(s.C(FieldContent), v))
+	},
+	)
+}
+
+// StagedEQ applies the EQ predicate on the "Staged" field.
+func StagedEQ(v bool) predicate.Job {
+	return predicate.Job(func(s *sql.Selector) {
+		s.Where(sql.EQ(s.C(FieldStaged), v))
+	},
+	)
+}
+
+// StagedNEQ applies the NEQ predicate on the "Staged" field.
+func StagedNEQ(v bool) predicate.Job {
+	return predicate.Job(func(s *sql.Selector) {
+		s.Where(sql.NEQ(s.C(FieldStaged), v))
 	},
 	)
 }

--- a/ent/job_create.go
+++ b/ent/job_create.go
@@ -62,14 +62,6 @@ func (jc *JobCreate) SetStaged(b bool) *JobCreate {
 	return jc
 }
 
-// SetNillableStaged sets the Staged field if the given value is not nil.
-func (jc *JobCreate) SetNillableStaged(b *bool) *JobCreate {
-	if b != nil {
-		jc.SetStaged(*b)
-	}
-	return jc
-}
-
 // AddTaskIDs adds the tasks edge to Task by ids.
 func (jc *JobCreate) AddTaskIDs(ids ...int) *JobCreate {
 	if jc.tasks == nil {
@@ -187,8 +179,7 @@ func (jc *JobCreate) Save(ctx context.Context) (*Job, error) {
 		return nil, fmt.Errorf("ent: validator failed for field \"Content\": %v", err)
 	}
 	if jc.Staged == nil {
-		v := job.DefaultStaged
-		jc.Staged = &v
+		return nil, errors.New("ent: missing required field \"Staged\"")
 	}
 	if len(jc.prev) > 1 {
 		return nil, errors.New("ent: multiple assignments on a unique edge \"prev\"")

--- a/ent/job_delete.go
+++ b/ent/job_delete.go
@@ -39,7 +39,7 @@ func (jd *JobDelete) ExecX(ctx context.Context) int {
 }
 
 func (jd *JobDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: job.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (jd *JobDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := jd.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, jd.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, jd.driver, _spec)
 }
 
 // JobDeleteOne is the builder for deleting a single Job entity.

--- a/ent/job_query.go
+++ b/ent/job_query.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"math"
@@ -26,6 +27,13 @@ type JobQuery struct {
 	order      []Order
 	unique     []string
 	predicates []predicate.Job
+	// eager-loading edges.
+	withTasks *TaskQuery
+	withTags  *TagQuery
+	withPrev  *JobQuery
+	withNext  *JobQuery
+	withOwner *UserQuery
+	withFKs   bool
 	// intermediate query.
 	sql *sql.Selector
 }
@@ -283,6 +291,61 @@ func (jq *JobQuery) Clone() *JobQuery {
 	}
 }
 
+//  WithTasks tells the query-builder to eager-loads the nodes that are connected to
+// the "tasks" edge. The optional arguments used to configure the query builder of the edge.
+func (jq *JobQuery) WithTasks(opts ...func(*TaskQuery)) *JobQuery {
+	query := &TaskQuery{config: jq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	jq.withTasks = query
+	return jq
+}
+
+//  WithTags tells the query-builder to eager-loads the nodes that are connected to
+// the "tags" edge. The optional arguments used to configure the query builder of the edge.
+func (jq *JobQuery) WithTags(opts ...func(*TagQuery)) *JobQuery {
+	query := &TagQuery{config: jq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	jq.withTags = query
+	return jq
+}
+
+//  WithPrev tells the query-builder to eager-loads the nodes that are connected to
+// the "prev" edge. The optional arguments used to configure the query builder of the edge.
+func (jq *JobQuery) WithPrev(opts ...func(*JobQuery)) *JobQuery {
+	query := &JobQuery{config: jq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	jq.withPrev = query
+	return jq
+}
+
+//  WithNext tells the query-builder to eager-loads the nodes that are connected to
+// the "next" edge. The optional arguments used to configure the query builder of the edge.
+func (jq *JobQuery) WithNext(opts ...func(*JobQuery)) *JobQuery {
+	query := &JobQuery{config: jq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	jq.withNext = query
+	return jq
+}
+
+//  WithOwner tells the query-builder to eager-loads the nodes that are connected to
+// the "owner" edge. The optional arguments used to configure the query builder of the edge.
+func (jq *JobQuery) WithOwner(opts ...func(*UserQuery)) *JobQuery {
+	query := &UserQuery{config: jq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	jq.withOwner = query
+	return jq
+}
+
 // GroupBy used to group vertices by one or more fields/columns.
 // It is often used with aggregate functions, like: count, max, mean, min, sum.
 //
@@ -326,30 +389,215 @@ func (jq *JobQuery) Select(field string, fields ...string) *JobSelect {
 
 func (jq *JobQuery) sqlAll(ctx context.Context) ([]*Job, error) {
 	var (
-		nodes []*Job
-		spec  = jq.querySpec()
+		nodes   []*Job
+		withFKs = jq.withFKs
+		_spec   = jq.querySpec()
 	)
-	spec.ScanValues = func() []interface{} {
+	if jq.withPrev != nil || jq.withOwner != nil {
+		withFKs = true
+	}
+	if withFKs {
+		_spec.Node.Columns = append(_spec.Node.Columns, job.ForeignKeys...)
+	}
+	_spec.ScanValues = func() []interface{} {
 		node := &Job{config: jq.config}
 		nodes = append(nodes, node)
-		return node.scanValues()
+		values := node.scanValues()
+		if withFKs {
+			values = append(values, node.fkValues()...)
+		}
+		return values
 	}
-	spec.Assign = func(values ...interface{}) error {
+	_spec.Assign = func(values ...interface{}) error {
 		if len(nodes) == 0 {
 			return fmt.Errorf("ent: Assign called without calling ScanValues")
 		}
 		node := nodes[len(nodes)-1]
 		return node.assignValues(values...)
 	}
-	if err := sqlgraph.QueryNodes(ctx, jq.driver, spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, jq.driver, _spec); err != nil {
 		return nil, err
 	}
+
+	if len(nodes) == 0 {
+		return nodes, nil
+	}
+
+	if query := jq.withTasks; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		nodeids := make(map[int]*Job)
+		for i := range nodes {
+			fks = append(fks, nodes[i].ID)
+			nodeids[nodes[i].ID] = nodes[i]
+		}
+		query.withFKs = true
+		query.Where(predicate.Task(func(s *sql.Selector) {
+			s.Where(sql.InValues(job.TasksColumn, fks...))
+		}))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			fk := n.job_id
+			if fk == nil {
+				return nil, fmt.Errorf(`foreign-key "job_id" is nil for node %v`, n.ID)
+			}
+			node, ok := nodeids[*fk]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "job_id" returned %v for node %v`, *fk, n.ID)
+			}
+			node.Edges.Tasks = append(node.Edges.Tasks, n)
+		}
+	}
+
+	if query := jq.withTags; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		ids := make(map[int]*Job, len(nodes))
+		for _, node := range nodes {
+			ids[node.ID] = node
+			fks = append(fks, node.ID)
+		}
+		var (
+			edgeids []int
+			edges   = make(map[int][]*Job)
+		)
+		_spec := &sqlgraph.EdgeQuerySpec{
+			Edge: &sqlgraph.EdgeSpec{
+				Inverse: false,
+				Table:   job.TagsTable,
+				Columns: job.TagsPrimaryKey,
+			},
+			Predicate: func(s *sql.Selector) {
+				s.Where(sql.InValues(job.TagsPrimaryKey[0], fks...))
+			},
+
+			ScanValues: func() [2]interface{} {
+				return [2]interface{}{&sql.NullInt64{}, &sql.NullInt64{}}
+			},
+			Assign: func(out, in interface{}) error {
+				eout, ok := out.(*sql.NullInt64)
+				if !ok || eout == nil {
+					return fmt.Errorf("unexpected id value for edge-out")
+				}
+				ein, ok := in.(*sql.NullInt64)
+				if !ok || ein == nil {
+					return fmt.Errorf("unexpected id value for edge-in")
+				}
+				outValue := int(eout.Int64)
+				inValue := int(eout.Int64)
+				node, ok := ids[outValue]
+				if !ok {
+					return fmt.Errorf("unexpected node id in edges: %v", outValue)
+				}
+				edgeids = append(edgeids, inValue)
+				edges[inValue] = append(edges[inValue], node)
+				return nil
+			},
+		}
+		if err := sqlgraph.QueryEdges(ctx, jq.driver, _spec); err != nil {
+			return nil, fmt.Errorf(`query edges "tags": %v`, err)
+		}
+		query.Where(tag.IDIn(edgeids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := edges[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected "tags" node returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Tags = append(nodes[i].Edges.Tags, n)
+			}
+		}
+	}
+
+	if query := jq.withPrev; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Job)
+		for i := range nodes {
+			if fk := nodes[i].prev_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(job.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "prev_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Prev = n
+			}
+		}
+	}
+
+	if query := jq.withNext; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		nodeids := make(map[int]*Job)
+		for i := range nodes {
+			fks = append(fks, nodes[i].ID)
+			nodeids[nodes[i].ID] = nodes[i]
+		}
+		query.withFKs = true
+		query.Where(predicate.Job(func(s *sql.Selector) {
+			s.Where(sql.InValues(job.NextColumn, fks...))
+		}))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			fk := n.prev_id
+			if fk == nil {
+				return nil, fmt.Errorf(`foreign-key "prev_id" is nil for node %v`, n.ID)
+			}
+			node, ok := nodeids[*fk]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "prev_id" returned %v for node %v`, *fk, n.ID)
+			}
+			node.Edges.Next = n
+		}
+	}
+
+	if query := jq.withOwner; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Job)
+		for i := range nodes {
+			if fk := nodes[i].owner_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(user.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Owner = n
+			}
+		}
+	}
+
 	return nodes, nil
 }
 
 func (jq *JobQuery) sqlCount(ctx context.Context) (int, error) {
-	spec := jq.querySpec()
-	return sqlgraph.CountNodes(ctx, jq.driver, spec)
+	_spec := jq.querySpec()
+	return sqlgraph.CountNodes(ctx, jq.driver, _spec)
 }
 
 func (jq *JobQuery) sqlExist(ctx context.Context) (bool, error) {
@@ -361,7 +609,7 @@ func (jq *JobQuery) sqlExist(ctx context.Context) (bool, error) {
 }
 
 func (jq *JobQuery) querySpec() *sqlgraph.QuerySpec {
-	spec := &sqlgraph.QuerySpec{
+	_spec := &sqlgraph.QuerySpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   job.Table,
 			Columns: job.Columns,
@@ -374,26 +622,26 @@ func (jq *JobQuery) querySpec() *sqlgraph.QuerySpec {
 		Unique: true,
 	}
 	if ps := jq.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if limit := jq.limit; limit != nil {
-		spec.Limit = *limit
+		_spec.Limit = *limit
 	}
 	if offset := jq.offset; offset != nil {
-		spec.Offset = *offset
+		_spec.Offset = *offset
 	}
 	if ps := jq.order; len(ps) > 0 {
-		spec.Order = func(selector *sql.Selector) {
+		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return spec
+	return _spec
 }
 
 func (jq *JobQuery) sqlQuery() *sql.Selector {

--- a/ent/job_update.go
+++ b/ent/job_update.go
@@ -24,6 +24,7 @@ type JobUpdate struct {
 	Name         *string
 	CreationTime *time.Time
 	Content      *string
+	Staged       *bool
 	tasks        map[int]struct{}
 	tags         map[int]struct{}
 	prev         map[int]struct{}
@@ -66,6 +67,20 @@ func (ju *JobUpdate) SetNillableCreationTime(t *time.Time) *JobUpdate {
 // SetContent sets the Content field.
 func (ju *JobUpdate) SetContent(s string) *JobUpdate {
 	ju.Content = &s
+	return ju
+}
+
+// SetStaged sets the Staged field.
+func (ju *JobUpdate) SetStaged(b bool) *JobUpdate {
+	ju.Staged = &b
+	return ju
+}
+
+// SetNillableStaged sets the Staged field if the given value is not nil.
+func (ju *JobUpdate) SetNillableStaged(b *bool) *JobUpdate {
+	if b != nil {
+		ju.SetStaged(*b)
+	}
 	return ju
 }
 
@@ -275,7 +290,7 @@ func (ju *JobUpdate) ExecX(ctx context.Context) {
 }
 
 func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   job.Table,
 			Columns: job.Columns,
@@ -286,31 +301,38 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := ju.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := ju.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: job.FieldName,
 		})
 	}
 	if value := ju.CreationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: job.FieldCreationTime,
 		})
 	}
 	if value := ju.Content; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: job.FieldContent,
+		})
+	}
+	if value := ju.Staged; value != nil {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  *value,
+			Column: job.FieldStaged,
 		})
 	}
 	if nodes := ju.removedTasks; len(nodes) > 0 {
@@ -330,7 +352,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ju.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -349,7 +371,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := ju.removedTags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -368,7 +390,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ju.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -387,7 +409,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if ju.clearedPrev {
 		edge := &sqlgraph.EdgeSpec{
@@ -403,7 +425,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ju.prev; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -422,7 +444,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if ju.clearedNext {
 		edge := &sqlgraph.EdgeSpec{
@@ -438,7 +460,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ju.next; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -457,7 +479,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if ju.clearedOwner {
 		edge := &sqlgraph.EdgeSpec{
@@ -473,7 +495,7 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ju.owner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -492,9 +514,9 @@ func (ju *JobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, ju.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, ju.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -510,6 +532,7 @@ type JobUpdateOne struct {
 	Name         *string
 	CreationTime *time.Time
 	Content      *string
+	Staged       *bool
 	tasks        map[int]struct{}
 	tags         map[int]struct{}
 	prev         map[int]struct{}
@@ -545,6 +568,20 @@ func (juo *JobUpdateOne) SetNillableCreationTime(t *time.Time) *JobUpdateOne {
 // SetContent sets the Content field.
 func (juo *JobUpdateOne) SetContent(s string) *JobUpdateOne {
 	juo.Content = &s
+	return juo
+}
+
+// SetStaged sets the Staged field.
+func (juo *JobUpdateOne) SetStaged(b bool) *JobUpdateOne {
+	juo.Staged = &b
+	return juo
+}
+
+// SetNillableStaged sets the Staged field if the given value is not nil.
+func (juo *JobUpdateOne) SetNillableStaged(b *bool) *JobUpdateOne {
+	if b != nil {
+		juo.SetStaged(*b)
+	}
 	return juo
 }
 
@@ -754,7 +791,7 @@ func (juo *JobUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   job.Table,
 			Columns: job.Columns,
@@ -766,24 +803,31 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		},
 	}
 	if value := juo.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: job.FieldName,
 		})
 	}
 	if value := juo.CreationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: job.FieldCreationTime,
 		})
 	}
 	if value := juo.Content; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: job.FieldContent,
+		})
+	}
+	if value := juo.Staged; value != nil {
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
+			Type:   field.TypeBool,
+			Value:  *value,
+			Column: job.FieldStaged,
 		})
 	}
 	if nodes := juo.removedTasks; len(nodes) > 0 {
@@ -803,7 +847,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := juo.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -822,7 +866,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := juo.removedTags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -841,7 +885,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := juo.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -860,7 +904,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if juo.clearedPrev {
 		edge := &sqlgraph.EdgeSpec{
@@ -876,7 +920,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := juo.prev; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -895,7 +939,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if juo.clearedNext {
 		edge := &sqlgraph.EdgeSpec{
@@ -911,7 +955,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := juo.next; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -930,7 +974,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if juo.clearedOwner {
 		edge := &sqlgraph.EdgeSpec{
@@ -946,7 +990,7 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := juo.owner; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -965,12 +1009,12 @@ func (juo *JobUpdateOne) sqlSave(ctx context.Context) (j *Job, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	j = &Job{config: juo.config}
-	spec.Assign = j.assignValues
-	spec.ScanValues = j.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, juo.driver, spec); err != nil {
+	_spec.Assign = j.assignValues
+	_spec.ScanValues = j.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, juo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/job_update.go
+++ b/ent/job_update.go
@@ -76,14 +76,6 @@ func (ju *JobUpdate) SetStaged(b bool) *JobUpdate {
 	return ju
 }
 
-// SetNillableStaged sets the Staged field if the given value is not nil.
-func (ju *JobUpdate) SetNillableStaged(b *bool) *JobUpdate {
-	if b != nil {
-		ju.SetStaged(*b)
-	}
-	return ju
-}
-
 // AddTaskIDs adds the tasks edge to Task by ids.
 func (ju *JobUpdate) AddTaskIDs(ids ...int) *JobUpdate {
 	if ju.tasks == nil {
@@ -574,14 +566,6 @@ func (juo *JobUpdateOne) SetContent(s string) *JobUpdateOne {
 // SetStaged sets the Staged field.
 func (juo *JobUpdateOne) SetStaged(b bool) *JobUpdateOne {
 	juo.Staged = &b
-	return juo
-}
-
-// SetNillableStaged sets the Staged field if the given value is not nil.
-func (juo *JobUpdateOne) SetNillableStaged(b *bool) *JobUpdateOne {
-	if b != nil {
-		juo.SetStaged(*b)
-	}
 	return juo
 }
 

--- a/ent/link/link.go
+++ b/ent/link/link.go
@@ -29,12 +29,17 @@ const (
 	FileColumn = "file_id"
 )
 
-// Columns holds all SQL columns are link fields.
+// Columns holds all SQL columns for link fields.
 var Columns = []string{
 	FieldID,
 	FieldAlias,
 	FieldExpirationTime,
 	FieldClicks,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the Link type.
+var ForeignKeys = []string{
+	"file_id",
 }
 
 var (

--- a/ent/link_create.go
+++ b/ent/link_create.go
@@ -111,8 +111,8 @@ func (lc *LinkCreate) SaveX(ctx context.Context) *Link {
 
 func (lc *LinkCreate) sqlSave(ctx context.Context) (*Link, error) {
 	var (
-		l    = &Link{config: lc.config}
-		spec = &sqlgraph.CreateSpec{
+		l     = &Link{config: lc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: link.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -121,7 +121,7 @@ func (lc *LinkCreate) sqlSave(ctx context.Context) (*Link, error) {
 		}
 	)
 	if value := lc.Alias; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: link.FieldAlias,
@@ -129,7 +129,7 @@ func (lc *LinkCreate) sqlSave(ctx context.Context) (*Link, error) {
 		l.Alias = *value
 	}
 	if value := lc.ExpirationTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: link.FieldExpirationTime,
@@ -137,7 +137,7 @@ func (lc *LinkCreate) sqlSave(ctx context.Context) (*Link, error) {
 		l.ExpirationTime = *value
 	}
 	if value := lc.Clicks; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: link.FieldClicks,
@@ -161,15 +161,15 @@ func (lc *LinkCreate) sqlSave(ctx context.Context) (*Link, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, lc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, lc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	l.ID = int(id)
 	return l, nil
 }

--- a/ent/link_delete.go
+++ b/ent/link_delete.go
@@ -39,7 +39,7 @@ func (ld *LinkDelete) ExecX(ctx context.Context) int {
 }
 
 func (ld *LinkDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: link.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (ld *LinkDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := ld.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, ld.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, ld.driver, _spec)
 }
 
 // LinkDeleteOne is the builder for deleting a single Link entity.

--- a/ent/link_query.go
+++ b/ent/link_query.go
@@ -24,6 +24,9 @@ type LinkQuery struct {
 	order      []Order
 	unique     []string
 	predicates []predicate.Link
+	// eager-loading edges.
+	withFile *FileQuery
+	withFKs  bool
 	// intermediate query.
 	sql *sql.Selector
 }
@@ -233,6 +236,17 @@ func (lq *LinkQuery) Clone() *LinkQuery {
 	}
 }
 
+//  WithFile tells the query-builder to eager-loads the nodes that are connected to
+// the "file" edge. The optional arguments used to configure the query builder of the edge.
+func (lq *LinkQuery) WithFile(opts ...func(*FileQuery)) *LinkQuery {
+	query := &FileQuery{config: lq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	lq.withFile = query
+	return lq
+}
+
 // GroupBy used to group vertices by one or more fields/columns.
 // It is often used with aggregate functions, like: count, max, mean, min, sum.
 //
@@ -276,30 +290,71 @@ func (lq *LinkQuery) Select(field string, fields ...string) *LinkSelect {
 
 func (lq *LinkQuery) sqlAll(ctx context.Context) ([]*Link, error) {
 	var (
-		nodes []*Link
-		spec  = lq.querySpec()
+		nodes   []*Link
+		withFKs = lq.withFKs
+		_spec   = lq.querySpec()
 	)
-	spec.ScanValues = func() []interface{} {
+	if lq.withFile != nil {
+		withFKs = true
+	}
+	if withFKs {
+		_spec.Node.Columns = append(_spec.Node.Columns, link.ForeignKeys...)
+	}
+	_spec.ScanValues = func() []interface{} {
 		node := &Link{config: lq.config}
 		nodes = append(nodes, node)
-		return node.scanValues()
+		values := node.scanValues()
+		if withFKs {
+			values = append(values, node.fkValues()...)
+		}
+		return values
 	}
-	spec.Assign = func(values ...interface{}) error {
+	_spec.Assign = func(values ...interface{}) error {
 		if len(nodes) == 0 {
 			return fmt.Errorf("ent: Assign called without calling ScanValues")
 		}
 		node := nodes[len(nodes)-1]
 		return node.assignValues(values...)
 	}
-	if err := sqlgraph.QueryNodes(ctx, lq.driver, spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, lq.driver, _spec); err != nil {
 		return nil, err
 	}
+
+	if len(nodes) == 0 {
+		return nodes, nil
+	}
+
+	if query := lq.withFile; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Link)
+		for i := range nodes {
+			if fk := nodes[i].file_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(file.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "file_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.File = n
+			}
+		}
+	}
+
 	return nodes, nil
 }
 
 func (lq *LinkQuery) sqlCount(ctx context.Context) (int, error) {
-	spec := lq.querySpec()
-	return sqlgraph.CountNodes(ctx, lq.driver, spec)
+	_spec := lq.querySpec()
+	return sqlgraph.CountNodes(ctx, lq.driver, _spec)
 }
 
 func (lq *LinkQuery) sqlExist(ctx context.Context) (bool, error) {
@@ -311,7 +366,7 @@ func (lq *LinkQuery) sqlExist(ctx context.Context) (bool, error) {
 }
 
 func (lq *LinkQuery) querySpec() *sqlgraph.QuerySpec {
-	spec := &sqlgraph.QuerySpec{
+	_spec := &sqlgraph.QuerySpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   link.Table,
 			Columns: link.Columns,
@@ -324,26 +379,26 @@ func (lq *LinkQuery) querySpec() *sqlgraph.QuerySpec {
 		Unique: true,
 	}
 	if ps := lq.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if limit := lq.limit; limit != nil {
-		spec.Limit = *limit
+		_spec.Limit = *limit
 	}
 	if offset := lq.offset; offset != nil {
-		spec.Offset = *offset
+		_spec.Offset = *offset
 	}
 	if ps := lq.order; len(ps) > 0 {
-		spec.Order = func(selector *sql.Selector) {
+		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return spec
+	return _spec
 }
 
 func (lq *LinkQuery) sqlQuery() *sql.Selector {

--- a/ent/link_update.go
+++ b/ent/link_update.go
@@ -156,7 +156,7 @@ func (lu *LinkUpdate) ExecX(ctx context.Context) {
 }
 
 func (lu *LinkUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   link.Table,
 			Columns: link.Columns,
@@ -167,41 +167,41 @@ func (lu *LinkUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := lu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := lu.Alias; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: link.FieldAlias,
 		})
 	}
 	if value := lu.ExpirationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: link.FieldExpirationTime,
 		})
 	}
 	if lu.clearExpirationTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: link.FieldExpirationTime,
 		})
 	}
 	if value := lu.Clicks; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: link.FieldClicks,
 		})
 	}
 	if value := lu.addClicks; value != nil {
-		spec.Fields.Add = append(spec.Fields.Add, &sqlgraph.FieldSpec{
+		_spec.Fields.Add = append(_spec.Fields.Add, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: link.FieldClicks,
@@ -221,7 +221,7 @@ func (lu *LinkUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := lu.file; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -240,9 +240,9 @@ func (lu *LinkUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, lu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, lu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -385,7 +385,7 @@ func (luo *LinkUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (luo *LinkUpdateOne) sqlSave(ctx context.Context) (l *Link, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   link.Table,
 			Columns: link.Columns,
@@ -397,34 +397,34 @@ func (luo *LinkUpdateOne) sqlSave(ctx context.Context) (l *Link, err error) {
 		},
 	}
 	if value := luo.Alias; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: link.FieldAlias,
 		})
 	}
 	if value := luo.ExpirationTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: link.FieldExpirationTime,
 		})
 	}
 	if luo.clearExpirationTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: link.FieldExpirationTime,
 		})
 	}
 	if value := luo.Clicks; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: link.FieldClicks,
 		})
 	}
 	if value := luo.addClicks; value != nil {
-		spec.Fields.Add = append(spec.Fields.Add, &sqlgraph.FieldSpec{
+		_spec.Fields.Add = append(_spec.Fields.Add, &sqlgraph.FieldSpec{
 			Type:   field.TypeInt,
 			Value:  *value,
 			Column: link.FieldClicks,
@@ -444,7 +444,7 @@ func (luo *LinkUpdateOne) sqlSave(ctx context.Context) (l *Link, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := luo.file; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -463,12 +463,12 @@ func (luo *LinkUpdateOne) sqlSave(ctx context.Context) (l *Link, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	l = &Link{config: luo.config}
-	spec.Assign = l.assignValues
-	spec.ScanValues = l.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, luo.driver, spec); err != nil {
+	_spec.Assign = l.assignValues
+	_spec.ScanValues = l.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, luo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -5,6 +5,7 @@ package migrate
 import (
 	"github.com/kcarretto/paragon/ent/credential"
 	"github.com/kcarretto/paragon/ent/file"
+	"github.com/kcarretto/paragon/ent/job"
 	"github.com/kcarretto/paragon/ent/link"
 	"github.com/kcarretto/paragon/ent/service"
 	"github.com/kcarretto/paragon/ent/user"
@@ -172,6 +173,7 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "creation_time", Type: field.TypeTime},
 		{Name: "content", Type: field.TypeString},
+		{Name: "staged", Type: field.TypeBool, Default: job.DefaultStaged},
 		{Name: "prev_id", Type: field.TypeInt, Unique: true, Nullable: true},
 		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
 	}
@@ -183,14 +185,14 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:  "jobs_jobs_next",
-				Columns: []*schema.Column{JobsColumns[4]},
+				Columns: []*schema.Column{JobsColumns[5]},
 
 				RefColumns: []*schema.Column{JobsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:  "jobs_users_jobs",
-				Columns: []*schema.Column{JobsColumns[5]},
+				Columns: []*schema.Column{JobsColumns[6]},
 
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -5,7 +5,6 @@ package migrate
 import (
 	"github.com/kcarretto/paragon/ent/credential"
 	"github.com/kcarretto/paragon/ent/file"
-	"github.com/kcarretto/paragon/ent/job"
 	"github.com/kcarretto/paragon/ent/link"
 	"github.com/kcarretto/paragon/ent/service"
 	"github.com/kcarretto/paragon/ent/user"
@@ -173,7 +172,7 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "creation_time", Type: field.TypeTime},
 		{Name: "content", Type: field.TypeString},
-		{Name: "staged", Type: field.TypeBool, Default: job.DefaultStaged},
+		{Name: "staged", Type: field.TypeBool},
 		{Name: "prev_id", Type: field.TypeInt, Unique: true, Nullable: true},
 		{Name: "owner_id", Type: field.TypeInt, Nullable: true},
 	}

--- a/ent/schema/job.go
+++ b/ent/schema/job.go
@@ -28,8 +28,7 @@ func (Job) Fields() []ent.Field {
 			NotEmpty().
 			Comment("The content of the job (usually a Renegade Script)"),
 		field.Bool("Staged").
-			Default(false).
-			Comment("The boolean that represents if a job's tasks shall be emitted/returned from claimTasks"),
+			Comment("The boolean that represents if a job's tasks shall be emitted/returned from claimTasks (false means yes)"),
 	}
 }
 

--- a/ent/schema/job.go
+++ b/ent/schema/job.go
@@ -27,6 +27,9 @@ func (Job) Fields() []ent.Field {
 		field.String("Content").
 			NotEmpty().
 			Comment("The content of the job (usually a Renegade Script)"),
+		field.Bool("Staged").
+			Default(false).
+			Comment("The boolean that represents if a job's tasks shall be emitted/returned from claimTasks"),
 	}
 }
 

--- a/ent/schema/task.go
+++ b/ent/schema/task.go
@@ -1,16 +1,12 @@
 package schema
 
 import (
-	"math"
 	"time"
 
 	"github.com/facebookincubator/ent"
 	"github.com/facebookincubator/ent/schema/edge"
 	"github.com/facebookincubator/ent/schema/field"
 )
-
-const MaxTaskContentSize = 65535
-const MaxTaskOutputSize = math.MaxUint32
 
 // Task holds the schema definition for the Task entity.
 type Task struct {

--- a/ent/service/service.go
+++ b/ent/service/service.go
@@ -36,12 +36,17 @@ const (
 	EventsColumn = "svc_owner_id"
 )
 
-// Columns holds all SQL columns are service fields.
+// Columns holds all SQL columns for service fields.
 var Columns = []string{
 	FieldID,
 	FieldName,
 	FieldPubKey,
 	FieldIsActivated,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the Service type.
+var ForeignKeys = []string{
+	"service_tag_id",
 }
 
 var (

--- a/ent/service_create.go
+++ b/ent/service_create.go
@@ -122,8 +122,8 @@ func (sc *ServiceCreate) SaveX(ctx context.Context) *Service {
 
 func (sc *ServiceCreate) sqlSave(ctx context.Context) (*Service, error) {
 	var (
-		s    = &Service{config: sc.config}
-		spec = &sqlgraph.CreateSpec{
+		s     = &Service{config: sc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: service.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -132,7 +132,7 @@ func (sc *ServiceCreate) sqlSave(ctx context.Context) (*Service, error) {
 		}
 	)
 	if value := sc.Name; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: service.FieldName,
@@ -140,7 +140,7 @@ func (sc *ServiceCreate) sqlSave(ctx context.Context) (*Service, error) {
 		s.Name = *value
 	}
 	if value := sc.PubKey; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: service.FieldPubKey,
@@ -148,7 +148,7 @@ func (sc *ServiceCreate) sqlSave(ctx context.Context) (*Service, error) {
 		s.PubKey = *value
 	}
 	if value := sc.IsActivated; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: service.FieldIsActivated,
@@ -172,7 +172,7 @@ func (sc *ServiceCreate) sqlSave(ctx context.Context) (*Service, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := sc.events; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -191,15 +191,15 @@ func (sc *ServiceCreate) sqlSave(ctx context.Context) (*Service, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, sc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, sc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	s.ID = int(id)
 	return s, nil
 }

--- a/ent/service_delete.go
+++ b/ent/service_delete.go
@@ -39,7 +39,7 @@ func (sd *ServiceDelete) ExecX(ctx context.Context) int {
 }
 
 func (sd *ServiceDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: service.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (sd *ServiceDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := sd.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, sd.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, sd.driver, _spec)
 }
 
 // ServiceDeleteOne is the builder for deleting a single Service entity.

--- a/ent/service_update.go
+++ b/ent/service_update.go
@@ -165,7 +165,7 @@ func (su *ServiceUpdate) ExecX(ctx context.Context) {
 }
 
 func (su *ServiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   service.Table,
 			Columns: service.Columns,
@@ -176,28 +176,28 @@ func (su *ServiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := su.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := su.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: service.FieldName,
 		})
 	}
 	if value := su.PubKey; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: service.FieldPubKey,
 		})
 	}
 	if value := su.IsActivated; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: service.FieldIsActivated,
@@ -217,7 +217,7 @@ func (su *ServiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := su.tag; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -236,7 +236,7 @@ func (su *ServiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := su.removedEvents; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -255,7 +255,7 @@ func (su *ServiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := su.events; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -274,9 +274,9 @@ func (su *ServiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, su.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, su.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -428,7 +428,7 @@ func (suo *ServiceUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (suo *ServiceUpdateOne) sqlSave(ctx context.Context) (s *Service, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   service.Table,
 			Columns: service.Columns,
@@ -440,21 +440,21 @@ func (suo *ServiceUpdateOne) sqlSave(ctx context.Context) (s *Service, err error
 		},
 	}
 	if value := suo.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: service.FieldName,
 		})
 	}
 	if value := suo.PubKey; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: service.FieldPubKey,
 		})
 	}
 	if value := suo.IsActivated; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: service.FieldIsActivated,
@@ -474,7 +474,7 @@ func (suo *ServiceUpdateOne) sqlSave(ctx context.Context) (s *Service, err error
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := suo.tag; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -493,7 +493,7 @@ func (suo *ServiceUpdateOne) sqlSave(ctx context.Context) (s *Service, err error
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := suo.removedEvents; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -512,7 +512,7 @@ func (suo *ServiceUpdateOne) sqlSave(ctx context.Context) (s *Service, err error
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := suo.events; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -531,12 +531,12 @@ func (suo *ServiceUpdateOne) sqlSave(ctx context.Context) (s *Service, err error
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	s = &Service{config: suo.config}
-	spec.Assign = s.assignValues
-	spec.ScanValues = s.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, suo.driver, spec); err != nil {
+	_spec.Assign = s.assignValues
+	_spec.ScanValues = s.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, suo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/tag.go
+++ b/ent/tag.go
@@ -17,20 +17,30 @@ type Tag struct {
 	ID int `json:"id,omitempty"`
 	// Name holds the value of the "Name" field.
 	Name string `json:"Name,omitempty"`
+	// Edges holds the relations/edges for other nodes in the graph.
+	// The values are being populated by the TagQuery when eager-loading is set.
+	Edges struct {
+		// Targets holds the value of the targets edge.
+		Targets []*Target
+		// Tasks holds the value of the tasks edge.
+		Tasks []*Task
+		// Jobs holds the value of the jobs edge.
+		Jobs []*Job
+	} `json:"edges"`
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
 func (*Tag) scanValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{},
-		&sql.NullString{},
+		&sql.NullInt64{},  // id
+		&sql.NullString{}, // Name
 	}
 }
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the Tag fields.
 func (t *Tag) assignValues(values ...interface{}) error {
-	if m, n := len(values), len(tag.Columns); m != n {
+	if m, n := len(values), len(tag.Columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
 	value, ok := values[0].(*sql.NullInt64)

--- a/ent/tag/tag.go
+++ b/ent/tag/tag.go
@@ -33,7 +33,7 @@ const (
 	JobsInverseTable = "jobs"
 )
 
-// Columns holds all SQL columns are tag fields.
+// Columns holds all SQL columns for tag fields.
 var Columns = []string{
 	FieldID,
 	FieldName,

--- a/ent/tag_create.go
+++ b/ent/tag_create.go
@@ -112,8 +112,8 @@ func (tc *TagCreate) SaveX(ctx context.Context) *Tag {
 
 func (tc *TagCreate) sqlSave(ctx context.Context) (*Tag, error) {
 	var (
-		t    = &Tag{config: tc.config}
-		spec = &sqlgraph.CreateSpec{
+		t     = &Tag{config: tc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: tag.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -122,7 +122,7 @@ func (tc *TagCreate) sqlSave(ctx context.Context) (*Tag, error) {
 		}
 	)
 	if value := tc.Name; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: tag.FieldName,
@@ -146,7 +146,7 @@ func (tc *TagCreate) sqlSave(ctx context.Context) (*Tag, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := tc.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -165,7 +165,7 @@ func (tc *TagCreate) sqlSave(ctx context.Context) (*Tag, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := tc.jobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -184,15 +184,15 @@ func (tc *TagCreate) sqlSave(ctx context.Context) (*Tag, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, tc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, tc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	t.ID = int(id)
 	return t, nil
 }

--- a/ent/tag_delete.go
+++ b/ent/tag_delete.go
@@ -39,7 +39,7 @@ func (td *TagDelete) ExecX(ctx context.Context) int {
 }
 
 func (td *TagDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: tag.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (td *TagDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := td.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, td.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, td.driver, _spec)
 }
 
 // TagDeleteOne is the builder for deleting a single Tag entity.

--- a/ent/tag_update.go
+++ b/ent/tag_update.go
@@ -194,7 +194,7 @@ func (tu *TagUpdate) ExecX(ctx context.Context) {
 }
 
 func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   tag.Table,
 			Columns: tag.Columns,
@@ -205,14 +205,14 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := tu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := tu.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: tag.FieldName,
@@ -235,7 +235,7 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.targets; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -254,7 +254,7 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tu.removedTasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -273,7 +273,7 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -292,7 +292,7 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tu.removedJobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -311,7 +311,7 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.jobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -330,9 +330,9 @@ func (tu *TagUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -513,7 +513,7 @@ func (tuo *TagUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   tag.Table,
 			Columns: tag.Columns,
@@ -525,7 +525,7 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		},
 	}
 	if value := tuo.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: tag.FieldName,
@@ -548,7 +548,7 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.targets; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -567,7 +567,7 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tuo.removedTasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -586,7 +586,7 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -605,7 +605,7 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tuo.removedJobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -624,7 +624,7 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.jobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -643,12 +643,12 @@ func (tuo *TagUpdateOne) sqlSave(ctx context.Context) (t *Tag, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	t = &Tag{config: tuo.config}
-	spec.Assign = t.assignValues
-	spec.ScanValues = t.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, tuo.driver, spec); err != nil {
+	_spec.Assign = t.assignValues
+	_spec.ScanValues = t.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, tuo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/target.go
+++ b/ent/target.go
@@ -30,26 +30,36 @@ type Target struct {
 	Hostname string `json:"Hostname,omitempty"`
 	// LastSeen holds the value of the "LastSeen" field.
 	LastSeen time.Time `json:"LastSeen,omitempty"`
+	// Edges holds the relations/edges for other nodes in the graph.
+	// The values are being populated by the TargetQuery when eager-loading is set.
+	Edges struct {
+		// Tasks holds the value of the tasks edge.
+		Tasks []*Task
+		// Tags holds the value of the tags edge.
+		Tags []*Tag
+		// Credentials holds the value of the credentials edge.
+		Credentials []*Credential
+	} `json:"edges"`
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
 func (*Target) scanValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullTime{},
+		&sql.NullInt64{},  // id
+		&sql.NullString{}, // Name
+		&sql.NullString{}, // PrimaryIP
+		&sql.NullString{}, // MachineUUID
+		&sql.NullString{}, // PublicIP
+		&sql.NullString{}, // PrimaryMAC
+		&sql.NullString{}, // Hostname
+		&sql.NullTime{},   // LastSeen
 	}
 }
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the Target fields.
 func (t *Target) assignValues(values ...interface{}) error {
-	if m, n := len(values), len(target.Columns); m != n {
+	if m, n := len(values), len(target.Columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
 	value, ok := values[0].(*sql.NullInt64)

--- a/ent/target/target.go
+++ b/ent/target/target.go
@@ -49,7 +49,7 @@ const (
 	CredentialsColumn = "target_id"
 )
 
-// Columns holds all SQL columns are target fields.
+// Columns holds all SQL columns for target fields.
 var Columns = []string{
 	FieldID,
 	FieldName,

--- a/ent/target_create.go
+++ b/ent/target_create.go
@@ -200,8 +200,8 @@ func (tc *TargetCreate) SaveX(ctx context.Context) *Target {
 
 func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 	var (
-		t    = &Target{config: tc.config}
-		spec = &sqlgraph.CreateSpec{
+		t     = &Target{config: tc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: target.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -210,7 +210,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		}
 	)
 	if value := tc.Name; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldName,
@@ -218,7 +218,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		t.Name = *value
 	}
 	if value := tc.PrimaryIP; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPrimaryIP,
@@ -226,7 +226,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		t.PrimaryIP = *value
 	}
 	if value := tc.MachineUUID; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldMachineUUID,
@@ -234,7 +234,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		t.MachineUUID = *value
 	}
 	if value := tc.PublicIP; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPublicIP,
@@ -242,7 +242,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		t.PublicIP = *value
 	}
 	if value := tc.PrimaryMAC; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPrimaryMAC,
@@ -250,7 +250,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		t.PrimaryMAC = *value
 	}
 	if value := tc.Hostname; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldHostname,
@@ -258,7 +258,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		t.Hostname = *value
 	}
 	if value := tc.LastSeen; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: target.FieldLastSeen,
@@ -282,7 +282,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := tc.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -301,7 +301,7 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := tc.credentials; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -320,15 +320,15 @@ func (tc *TargetCreate) sqlSave(ctx context.Context) (*Target, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, tc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, tc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	t.ID = int(id)
 	return t, nil
 }

--- a/ent/target_delete.go
+++ b/ent/target_delete.go
@@ -39,7 +39,7 @@ func (td *TargetDelete) ExecX(ctx context.Context) int {
 }
 
 func (td *TargetDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: target.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (td *TargetDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := td.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, td.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, td.driver, _spec)
 }
 
 // TargetDeleteOne is the builder for deleting a single Target entity.

--- a/ent/target_query.go
+++ b/ent/target_query.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"math"
@@ -26,6 +27,10 @@ type TargetQuery struct {
 	order      []Order
 	unique     []string
 	predicates []predicate.Target
+	// eager-loading edges.
+	withTasks       *TaskQuery
+	withTags        *TagQuery
+	withCredentials *CredentialQuery
 	// intermediate query.
 	sql *sql.Selector
 }
@@ -259,6 +264,39 @@ func (tq *TargetQuery) Clone() *TargetQuery {
 	}
 }
 
+//  WithTasks tells the query-builder to eager-loads the nodes that are connected to
+// the "tasks" edge. The optional arguments used to configure the query builder of the edge.
+func (tq *TargetQuery) WithTasks(opts ...func(*TaskQuery)) *TargetQuery {
+	query := &TaskQuery{config: tq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tq.withTasks = query
+	return tq
+}
+
+//  WithTags tells the query-builder to eager-loads the nodes that are connected to
+// the "tags" edge. The optional arguments used to configure the query builder of the edge.
+func (tq *TargetQuery) WithTags(opts ...func(*TagQuery)) *TargetQuery {
+	query := &TagQuery{config: tq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tq.withTags = query
+	return tq
+}
+
+//  WithCredentials tells the query-builder to eager-loads the nodes that are connected to
+// the "credentials" edge. The optional arguments used to configure the query builder of the edge.
+func (tq *TargetQuery) WithCredentials(opts ...func(*CredentialQuery)) *TargetQuery {
+	query := &CredentialQuery{config: tq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tq.withCredentials = query
+	return tq
+}
+
 // GroupBy used to group vertices by one or more fields/columns.
 // It is often used with aggregate functions, like: count, max, mean, min, sum.
 //
@@ -303,29 +341,154 @@ func (tq *TargetQuery) Select(field string, fields ...string) *TargetSelect {
 func (tq *TargetQuery) sqlAll(ctx context.Context) ([]*Target, error) {
 	var (
 		nodes []*Target
-		spec  = tq.querySpec()
+		_spec = tq.querySpec()
 	)
-	spec.ScanValues = func() []interface{} {
+	_spec.ScanValues = func() []interface{} {
 		node := &Target{config: tq.config}
 		nodes = append(nodes, node)
-		return node.scanValues()
+		values := node.scanValues()
+		return values
 	}
-	spec.Assign = func(values ...interface{}) error {
+	_spec.Assign = func(values ...interface{}) error {
 		if len(nodes) == 0 {
 			return fmt.Errorf("ent: Assign called without calling ScanValues")
 		}
 		node := nodes[len(nodes)-1]
 		return node.assignValues(values...)
 	}
-	if err := sqlgraph.QueryNodes(ctx, tq.driver, spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, tq.driver, _spec); err != nil {
 		return nil, err
 	}
+
+	if len(nodes) == 0 {
+		return nodes, nil
+	}
+
+	if query := tq.withTasks; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		nodeids := make(map[int]*Target)
+		for i := range nodes {
+			fks = append(fks, nodes[i].ID)
+			nodeids[nodes[i].ID] = nodes[i]
+		}
+		query.withFKs = true
+		query.Where(predicate.Task(func(s *sql.Selector) {
+			s.Where(sql.InValues(target.TasksColumn, fks...))
+		}))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			fk := n.target_id
+			if fk == nil {
+				return nil, fmt.Errorf(`foreign-key "target_id" is nil for node %v`, n.ID)
+			}
+			node, ok := nodeids[*fk]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "target_id" returned %v for node %v`, *fk, n.ID)
+			}
+			node.Edges.Tasks = append(node.Edges.Tasks, n)
+		}
+	}
+
+	if query := tq.withTags; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		ids := make(map[int]*Target, len(nodes))
+		for _, node := range nodes {
+			ids[node.ID] = node
+			fks = append(fks, node.ID)
+		}
+		var (
+			edgeids []int
+			edges   = make(map[int][]*Target)
+		)
+		_spec := &sqlgraph.EdgeQuerySpec{
+			Edge: &sqlgraph.EdgeSpec{
+				Inverse: false,
+				Table:   target.TagsTable,
+				Columns: target.TagsPrimaryKey,
+			},
+			Predicate: func(s *sql.Selector) {
+				s.Where(sql.InValues(target.TagsPrimaryKey[0], fks...))
+			},
+
+			ScanValues: func() [2]interface{} {
+				return [2]interface{}{&sql.NullInt64{}, &sql.NullInt64{}}
+			},
+			Assign: func(out, in interface{}) error {
+				eout, ok := out.(*sql.NullInt64)
+				if !ok || eout == nil {
+					return fmt.Errorf("unexpected id value for edge-out")
+				}
+				ein, ok := in.(*sql.NullInt64)
+				if !ok || ein == nil {
+					return fmt.Errorf("unexpected id value for edge-in")
+				}
+				outValue := int(eout.Int64)
+				inValue := int(eout.Int64)
+				node, ok := ids[outValue]
+				if !ok {
+					return fmt.Errorf("unexpected node id in edges: %v", outValue)
+				}
+				edgeids = append(edgeids, inValue)
+				edges[inValue] = append(edges[inValue], node)
+				return nil
+			},
+		}
+		if err := sqlgraph.QueryEdges(ctx, tq.driver, _spec); err != nil {
+			return nil, fmt.Errorf(`query edges "tags": %v`, err)
+		}
+		query.Where(tag.IDIn(edgeids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := edges[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected "tags" node returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Tags = append(nodes[i].Edges.Tags, n)
+			}
+		}
+	}
+
+	if query := tq.withCredentials; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		nodeids := make(map[int]*Target)
+		for i := range nodes {
+			fks = append(fks, nodes[i].ID)
+			nodeids[nodes[i].ID] = nodes[i]
+		}
+		query.withFKs = true
+		query.Where(predicate.Credential(func(s *sql.Selector) {
+			s.Where(sql.InValues(target.CredentialsColumn, fks...))
+		}))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			fk := n.target_id
+			if fk == nil {
+				return nil, fmt.Errorf(`foreign-key "target_id" is nil for node %v`, n.ID)
+			}
+			node, ok := nodeids[*fk]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "target_id" returned %v for node %v`, *fk, n.ID)
+			}
+			node.Edges.Credentials = append(node.Edges.Credentials, n)
+		}
+	}
+
 	return nodes, nil
 }
 
 func (tq *TargetQuery) sqlCount(ctx context.Context) (int, error) {
-	spec := tq.querySpec()
-	return sqlgraph.CountNodes(ctx, tq.driver, spec)
+	_spec := tq.querySpec()
+	return sqlgraph.CountNodes(ctx, tq.driver, _spec)
 }
 
 func (tq *TargetQuery) sqlExist(ctx context.Context) (bool, error) {
@@ -337,7 +500,7 @@ func (tq *TargetQuery) sqlExist(ctx context.Context) (bool, error) {
 }
 
 func (tq *TargetQuery) querySpec() *sqlgraph.QuerySpec {
-	spec := &sqlgraph.QuerySpec{
+	_spec := &sqlgraph.QuerySpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   target.Table,
 			Columns: target.Columns,
@@ -350,26 +513,26 @@ func (tq *TargetQuery) querySpec() *sqlgraph.QuerySpec {
 		Unique: true,
 	}
 	if ps := tq.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if limit := tq.limit; limit != nil {
-		spec.Limit = *limit
+		_spec.Limit = *limit
 	}
 	if offset := tq.offset; offset != nil {
-		spec.Offset = *offset
+		_spec.Offset = *offset
 	}
 	if ps := tq.order; len(ps) > 0 {
-		spec.Order = func(selector *sql.Selector) {
+		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return spec
+	return _spec
 }
 
 func (tq *TargetQuery) sqlQuery() *sql.Selector {

--- a/ent/target_update.go
+++ b/ent/target_update.go
@@ -317,7 +317,7 @@ func (tu *TargetUpdate) ExecX(ctx context.Context) {
 }
 
 func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   target.Table,
 			Columns: target.Columns,
@@ -328,87 +328,87 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := tu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := tu.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldName,
 		})
 	}
 	if value := tu.PrimaryIP; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPrimaryIP,
 		})
 	}
 	if value := tu.MachineUUID; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldMachineUUID,
 		})
 	}
 	if tu.clearMachineUUID {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldMachineUUID,
 		})
 	}
 	if value := tu.PublicIP; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPublicIP,
 		})
 	}
 	if tu.clearPublicIP {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldPublicIP,
 		})
 	}
 	if value := tu.PrimaryMAC; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPrimaryMAC,
 		})
 	}
 	if tu.clearPrimaryMAC {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldPrimaryMAC,
 		})
 	}
 	if value := tu.Hostname; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldHostname,
 		})
 	}
 	if tu.clearHostname {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldHostname,
 		})
 	}
 	if value := tu.LastSeen; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: target.FieldLastSeen,
 		})
 	}
 	if tu.clearLastSeen {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: target.FieldLastSeen,
 		})
@@ -430,7 +430,7 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -449,7 +449,7 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tu.removedTags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -468,7 +468,7 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -487,7 +487,7 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tu.removedCredentials; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -506,7 +506,7 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.credentials; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -525,9 +525,9 @@ func (tu *TargetUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -830,7 +830,7 @@ func (tuo *TargetUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   target.Table,
 			Columns: target.Columns,
@@ -842,80 +842,80 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		},
 	}
 	if value := tuo.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldName,
 		})
 	}
 	if value := tuo.PrimaryIP; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPrimaryIP,
 		})
 	}
 	if value := tuo.MachineUUID; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldMachineUUID,
 		})
 	}
 	if tuo.clearMachineUUID {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldMachineUUID,
 		})
 	}
 	if value := tuo.PublicIP; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPublicIP,
 		})
 	}
 	if tuo.clearPublicIP {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldPublicIP,
 		})
 	}
 	if value := tuo.PrimaryMAC; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldPrimaryMAC,
 		})
 	}
 	if tuo.clearPrimaryMAC {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldPrimaryMAC,
 		})
 	}
 	if value := tuo.Hostname; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: target.FieldHostname,
 		})
 	}
 	if tuo.clearHostname {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: target.FieldHostname,
 		})
 	}
 	if value := tuo.LastSeen; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: target.FieldLastSeen,
 		})
 	}
 	if tuo.clearLastSeen {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: target.FieldLastSeen,
 		})
@@ -937,7 +937,7 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.tasks; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -956,7 +956,7 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tuo.removedTags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -975,7 +975,7 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -994,7 +994,7 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := tuo.removedCredentials; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1013,7 +1013,7 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.credentials; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1032,12 +1032,12 @@ func (tuo *TargetUpdateOne) sqlSave(ctx context.Context) (t *Target, err error) 
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	t = &Target{config: tuo.config}
-	spec.Assign = t.assignValues
-	spec.ScanValues = t.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, tuo.driver, spec); err != nil {
+	_spec.Assign = t.assignValues
+	_spec.ScanValues = t.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, tuo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/task.go
+++ b/ent/task.go
@@ -34,28 +34,48 @@ type Task struct {
 	Error string `json:"Error,omitempty"`
 	// SessionID holds the value of the "SessionID" field.
 	SessionID string `json:"SessionID,omitempty"`
+	// Edges holds the relations/edges for other nodes in the graph.
+	// The values are being populated by the TaskQuery when eager-loading is set.
+	Edges struct {
+		// Tags holds the value of the tags edge.
+		Tags []*Tag
+		// Job holds the value of the job edge.
+		Job *Job
+		// Target holds the value of the target edge.
+		Target *Target
+	} `json:"edges"`
+	job_id    *int
+	target_id *int
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
 func (*Task) scanValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{},
-		&sql.NullTime{},
-		&sql.NullTime{},
-		&sql.NullTime{},
-		&sql.NullTime{},
-		&sql.NullTime{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
+		&sql.NullInt64{},  // id
+		&sql.NullTime{},   // QueueTime
+		&sql.NullTime{},   // LastChangedTime
+		&sql.NullTime{},   // ClaimTime
+		&sql.NullTime{},   // ExecStartTime
+		&sql.NullTime{},   // ExecStopTime
+		&sql.NullString{}, // Content
+		&sql.NullString{}, // Output
+		&sql.NullString{}, // Error
+		&sql.NullString{}, // SessionID
+	}
+}
+
+// fkValues returns the types for scanning foreign-keys values from sql.Rows.
+func (*Task) fkValues() []interface{} {
+	return []interface{}{
+		&sql.NullInt64{}, // job_id
+		&sql.NullInt64{}, // target_id
 	}
 }
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the Task fields.
 func (t *Task) assignValues(values ...interface{}) error {
-	if m, n := len(values), len(task.Columns); m != n {
+	if m, n := len(values), len(task.Columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
 	value, ok := values[0].(*sql.NullInt64)
@@ -108,6 +128,21 @@ func (t *Task) assignValues(values ...interface{}) error {
 		return fmt.Errorf("unexpected type %T for field SessionID", values[8])
 	} else if value.Valid {
 		t.SessionID = value.String
+	}
+	values = values[9:]
+	if len(values) == len(task.ForeignKeys) {
+		if value, ok := values[0].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field job_id", value)
+		} else if value.Valid {
+			t.job_id = new(int)
+			*t.job_id = int(value.Int64)
+		}
+		if value, ok := values[1].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field target_id", value)
+		} else if value.Valid {
+			t.target_id = new(int)
+			*t.target_id = int(value.Int64)
+		}
 	}
 	return nil
 }

--- a/ent/task/task.go
+++ b/ent/task/task.go
@@ -55,7 +55,7 @@ const (
 	TargetColumn = "target_id"
 )
 
-// Columns holds all SQL columns are task fields.
+// Columns holds all SQL columns for task fields.
 var Columns = []string{
 	FieldID,
 	FieldQueueTime,
@@ -67,6 +67,12 @@ var Columns = []string{
 	FieldOutput,
 	FieldError,
 	FieldSessionID,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the Task type.
+var ForeignKeys = []string{
+	"job_id",
+	"target_id",
 }
 
 var (

--- a/ent/task_create.go
+++ b/ent/task_create.go
@@ -242,8 +242,8 @@ func (tc *TaskCreate) SaveX(ctx context.Context) *Task {
 
 func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 	var (
-		t    = &Task{config: tc.config}
-		spec = &sqlgraph.CreateSpec{
+		t     = &Task{config: tc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: task.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -252,7 +252,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		}
 	)
 	if value := tc.QueueTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldQueueTime,
@@ -260,7 +260,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.QueueTime = *value
 	}
 	if value := tc.LastChangedTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldLastChangedTime,
@@ -268,7 +268,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.LastChangedTime = *value
 	}
 	if value := tc.ClaimTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldClaimTime,
@@ -276,7 +276,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.ClaimTime = *value
 	}
 	if value := tc.ExecStartTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldExecStartTime,
@@ -284,7 +284,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.ExecStartTime = *value
 	}
 	if value := tc.ExecStopTime; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldExecStopTime,
@@ -292,7 +292,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.ExecStopTime = *value
 	}
 	if value := tc.Content; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldContent,
@@ -300,7 +300,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.Content = *value
 	}
 	if value := tc.Output; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldOutput,
@@ -308,7 +308,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.Output = *value
 	}
 	if value := tc.Error; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldError,
@@ -316,7 +316,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		t.Error = *value
 	}
 	if value := tc.SessionID; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldSessionID,
@@ -340,7 +340,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := tc.job; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -359,7 +359,7 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := tc.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -378,15 +378,15 @@ func (tc *TaskCreate) sqlSave(ctx context.Context) (*Task, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, tc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, tc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	t.ID = int(id)
 	return t, nil
 }

--- a/ent/task_delete.go
+++ b/ent/task_delete.go
@@ -39,7 +39,7 @@ func (td *TaskDelete) ExecX(ctx context.Context) int {
 }
 
 func (td *TaskDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: task.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (td *TaskDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := td.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, td.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, td.driver, _spec)
 }
 
 // TaskDeleteOne is the builder for deleting a single Task entity.

--- a/ent/task_query.go
+++ b/ent/task_query.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"math"
@@ -26,6 +27,11 @@ type TaskQuery struct {
 	order      []Order
 	unique     []string
 	predicates []predicate.Task
+	// eager-loading edges.
+	withTags   *TagQuery
+	withJob    *JobQuery
+	withTarget *TargetQuery
+	withFKs    bool
 	// intermediate query.
 	sql *sql.Selector
 }
@@ -259,6 +265,39 @@ func (tq *TaskQuery) Clone() *TaskQuery {
 	}
 }
 
+//  WithTags tells the query-builder to eager-loads the nodes that are connected to
+// the "tags" edge. The optional arguments used to configure the query builder of the edge.
+func (tq *TaskQuery) WithTags(opts ...func(*TagQuery)) *TaskQuery {
+	query := &TagQuery{config: tq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tq.withTags = query
+	return tq
+}
+
+//  WithJob tells the query-builder to eager-loads the nodes that are connected to
+// the "job" edge. The optional arguments used to configure the query builder of the edge.
+func (tq *TaskQuery) WithJob(opts ...func(*JobQuery)) *TaskQuery {
+	query := &JobQuery{config: tq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tq.withJob = query
+	return tq
+}
+
+//  WithTarget tells the query-builder to eager-loads the nodes that are connected to
+// the "target" edge. The optional arguments used to configure the query builder of the edge.
+func (tq *TaskQuery) WithTarget(opts ...func(*TargetQuery)) *TaskQuery {
+	query := &TargetQuery{config: tq.config}
+	for _, opt := range opts {
+		opt(query)
+	}
+	tq.withTarget = query
+	return tq
+}
+
 // GroupBy used to group vertices by one or more fields/columns.
 // It is often used with aggregate functions, like: count, max, mean, min, sum.
 //
@@ -302,30 +341,159 @@ func (tq *TaskQuery) Select(field string, fields ...string) *TaskSelect {
 
 func (tq *TaskQuery) sqlAll(ctx context.Context) ([]*Task, error) {
 	var (
-		nodes []*Task
-		spec  = tq.querySpec()
+		nodes   []*Task
+		withFKs = tq.withFKs
+		_spec   = tq.querySpec()
 	)
-	spec.ScanValues = func() []interface{} {
+	if tq.withJob != nil || tq.withTarget != nil {
+		withFKs = true
+	}
+	if withFKs {
+		_spec.Node.Columns = append(_spec.Node.Columns, task.ForeignKeys...)
+	}
+	_spec.ScanValues = func() []interface{} {
 		node := &Task{config: tq.config}
 		nodes = append(nodes, node)
-		return node.scanValues()
+		values := node.scanValues()
+		if withFKs {
+			values = append(values, node.fkValues()...)
+		}
+		return values
 	}
-	spec.Assign = func(values ...interface{}) error {
+	_spec.Assign = func(values ...interface{}) error {
 		if len(nodes) == 0 {
 			return fmt.Errorf("ent: Assign called without calling ScanValues")
 		}
 		node := nodes[len(nodes)-1]
 		return node.assignValues(values...)
 	}
-	if err := sqlgraph.QueryNodes(ctx, tq.driver, spec); err != nil {
+	if err := sqlgraph.QueryNodes(ctx, tq.driver, _spec); err != nil {
 		return nil, err
 	}
+
+	if len(nodes) == 0 {
+		return nodes, nil
+	}
+
+	if query := tq.withTags; query != nil {
+		fks := make([]driver.Value, 0, len(nodes))
+		ids := make(map[int]*Task, len(nodes))
+		for _, node := range nodes {
+			ids[node.ID] = node
+			fks = append(fks, node.ID)
+		}
+		var (
+			edgeids []int
+			edges   = make(map[int][]*Task)
+		)
+		_spec := &sqlgraph.EdgeQuerySpec{
+			Edge: &sqlgraph.EdgeSpec{
+				Inverse: false,
+				Table:   task.TagsTable,
+				Columns: task.TagsPrimaryKey,
+			},
+			Predicate: func(s *sql.Selector) {
+				s.Where(sql.InValues(task.TagsPrimaryKey[0], fks...))
+			},
+
+			ScanValues: func() [2]interface{} {
+				return [2]interface{}{&sql.NullInt64{}, &sql.NullInt64{}}
+			},
+			Assign: func(out, in interface{}) error {
+				eout, ok := out.(*sql.NullInt64)
+				if !ok || eout == nil {
+					return fmt.Errorf("unexpected id value for edge-out")
+				}
+				ein, ok := in.(*sql.NullInt64)
+				if !ok || ein == nil {
+					return fmt.Errorf("unexpected id value for edge-in")
+				}
+				outValue := int(eout.Int64)
+				inValue := int(eout.Int64)
+				node, ok := ids[outValue]
+				if !ok {
+					return fmt.Errorf("unexpected node id in edges: %v", outValue)
+				}
+				edgeids = append(edgeids, inValue)
+				edges[inValue] = append(edges[inValue], node)
+				return nil
+			},
+		}
+		if err := sqlgraph.QueryEdges(ctx, tq.driver, _spec); err != nil {
+			return nil, fmt.Errorf(`query edges "tags": %v`, err)
+		}
+		query.Where(tag.IDIn(edgeids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := edges[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected "tags" node returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Tags = append(nodes[i].Edges.Tags, n)
+			}
+		}
+	}
+
+	if query := tq.withJob; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Task)
+		for i := range nodes {
+			if fk := nodes[i].job_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(job.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "job_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Job = n
+			}
+		}
+	}
+
+	if query := tq.withTarget; query != nil {
+		ids := make([]int, 0, len(nodes))
+		nodeids := make(map[int][]*Task)
+		for i := range nodes {
+			if fk := nodes[i].target_id; fk != nil {
+				ids = append(ids, *fk)
+				nodeids[*fk] = append(nodeids[*fk], nodes[i])
+			}
+		}
+		query.Where(target.IDIn(ids...))
+		neighbors, err := query.All(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, n := range neighbors {
+			nodes, ok := nodeids[n.ID]
+			if !ok {
+				return nil, fmt.Errorf(`unexpected foreign-key "target_id" returned %v`, n.ID)
+			}
+			for i := range nodes {
+				nodes[i].Edges.Target = n
+			}
+		}
+	}
+
 	return nodes, nil
 }
 
 func (tq *TaskQuery) sqlCount(ctx context.Context) (int, error) {
-	spec := tq.querySpec()
-	return sqlgraph.CountNodes(ctx, tq.driver, spec)
+	_spec := tq.querySpec()
+	return sqlgraph.CountNodes(ctx, tq.driver, _spec)
 }
 
 func (tq *TaskQuery) sqlExist(ctx context.Context) (bool, error) {
@@ -337,7 +505,7 @@ func (tq *TaskQuery) sqlExist(ctx context.Context) (bool, error) {
 }
 
 func (tq *TaskQuery) querySpec() *sqlgraph.QuerySpec {
-	spec := &sqlgraph.QuerySpec{
+	_spec := &sqlgraph.QuerySpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   task.Table,
 			Columns: task.Columns,
@@ -350,26 +518,26 @@ func (tq *TaskQuery) querySpec() *sqlgraph.QuerySpec {
 		Unique: true,
 	}
 	if ps := tq.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if limit := tq.limit; limit != nil {
-		spec.Limit = *limit
+		_spec.Limit = *limit
 	}
 	if offset := tq.offset; offset != nil {
-		spec.Offset = *offset
+		_spec.Offset = *offset
 	}
 	if ps := tq.order; len(ps) > 0 {
-		spec.Order = func(selector *sql.Selector) {
+		_spec.Order = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return spec
+	return _spec
 }
 
 func (tq *TaskQuery) sqlQuery() *sql.Selector {

--- a/ent/task_update.go
+++ b/ent/task_update.go
@@ -338,7 +338,7 @@ func (tu *TaskUpdate) ExecX(ctx context.Context) {
 }
 
 func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   task.Table,
 			Columns: task.Columns,
@@ -349,107 +349,107 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := tu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := tu.QueueTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldQueueTime,
 		})
 	}
 	if value := tu.LastChangedTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldLastChangedTime,
 		})
 	}
 	if value := tu.ClaimTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldClaimTime,
 		})
 	}
 	if tu.clearClaimTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: task.FieldClaimTime,
 		})
 	}
 	if value := tu.ExecStartTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldExecStartTime,
 		})
 	}
 	if tu.clearExecStartTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: task.FieldExecStartTime,
 		})
 	}
 	if value := tu.ExecStopTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldExecStopTime,
 		})
 	}
 	if tu.clearExecStopTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: task.FieldExecStopTime,
 		})
 	}
 	if value := tu.Content; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldContent,
 		})
 	}
 	if value := tu.Output; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldOutput,
 		})
 	}
 	if tu.clearOutput {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: task.FieldOutput,
 		})
 	}
 	if value := tu.Error; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldError,
 		})
 	}
 	if tu.clearError {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: task.FieldError,
 		})
 	}
 	if value := tu.SessionID; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldSessionID,
 		})
 	}
 	if tu.clearSessionID {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: task.FieldSessionID,
 		})
@@ -471,7 +471,7 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -490,7 +490,7 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if tu.clearedJob {
 		edge := &sqlgraph.EdgeSpec{
@@ -506,7 +506,7 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.job; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -525,7 +525,7 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if tu.clearedTarget {
 		edge := &sqlgraph.EdgeSpec{
@@ -541,7 +541,7 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tu.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -560,9 +560,9 @@ func (tu *TaskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, tu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -885,7 +885,7 @@ func (tuo *TaskUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   task.Table,
 			Columns: task.Columns,
@@ -897,100 +897,100 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 		},
 	}
 	if value := tuo.QueueTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldQueueTime,
 		})
 	}
 	if value := tuo.LastChangedTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldLastChangedTime,
 		})
 	}
 	if value := tuo.ClaimTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldClaimTime,
 		})
 	}
 	if tuo.clearClaimTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: task.FieldClaimTime,
 		})
 	}
 	if value := tuo.ExecStartTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldExecStartTime,
 		})
 	}
 	if tuo.clearExecStartTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: task.FieldExecStartTime,
 		})
 	}
 	if value := tuo.ExecStopTime; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Value:  *value,
 			Column: task.FieldExecStopTime,
 		})
 	}
 	if tuo.clearExecStopTime {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeTime,
 			Column: task.FieldExecStopTime,
 		})
 	}
 	if value := tuo.Content; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldContent,
 		})
 	}
 	if value := tuo.Output; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldOutput,
 		})
 	}
 	if tuo.clearOutput {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: task.FieldOutput,
 		})
 	}
 	if value := tuo.Error; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldError,
 		})
 	}
 	if tuo.clearError {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: task.FieldError,
 		})
 	}
 	if value := tuo.SessionID; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: task.FieldSessionID,
 		})
 	}
 	if tuo.clearSessionID {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: task.FieldSessionID,
 		})
@@ -1012,7 +1012,7 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.tags; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1031,7 +1031,7 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if tuo.clearedJob {
 		edge := &sqlgraph.EdgeSpec{
@@ -1047,7 +1047,7 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.job; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1066,7 +1066,7 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if tuo.clearedTarget {
 		edge := &sqlgraph.EdgeSpec{
@@ -1082,7 +1082,7 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 				},
 			},
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := tuo.target; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1101,12 +1101,12 @@ func (tuo *TaskUpdateOne) sqlSave(ctx context.Context) (t *Task, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	t = &Task{config: tuo.config}
-	spec.Assign = t.assignValues
-	spec.ScanValues = t.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, tuo.driver, spec); err != nil {
+	_spec.Assign = t.assignValues
+	_spec.ScanValues = t.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, tuo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/ent/user.go
+++ b/ent/user.go
@@ -27,25 +27,41 @@ type User struct {
 	IsActivated bool `json:"IsActivated,omitempty"`
 	// IsAdmin holds the value of the "IsAdmin" field.
 	IsAdmin bool `json:"IsAdmin,omitempty"`
+	// Edges holds the relations/edges for other nodes in the graph.
+	// The values are being populated by the UserQuery when eager-loading is set.
+	Edges struct {
+		// Jobs holds the value of the jobs edge.
+		Jobs []*Job
+		// Events holds the value of the events edge.
+		Events []*Event
+	} `json:"edges"`
+	event_liker_id *int
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
 func (*User) scanValues() []interface{} {
 	return []interface{}{
-		&sql.NullInt64{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullString{},
-		&sql.NullBool{},
-		&sql.NullBool{},
+		&sql.NullInt64{},  // id
+		&sql.NullString{}, // Name
+		&sql.NullString{}, // OAuthID
+		&sql.NullString{}, // PhotoURL
+		&sql.NullString{}, // SessionToken
+		&sql.NullBool{},   // IsActivated
+		&sql.NullBool{},   // IsAdmin
+	}
+}
+
+// fkValues returns the types for scanning foreign-keys values from sql.Rows.
+func (*User) fkValues() []interface{} {
+	return []interface{}{
+		&sql.NullInt64{}, // event_liker_id
 	}
 }
 
 // assignValues assigns the values that were returned from sql.Rows (after scanning)
 // to the User fields.
 func (u *User) assignValues(values ...interface{}) error {
-	if m, n := len(values), len(user.Columns); m != n {
+	if m, n := len(values), len(user.Columns); m < n {
 		return fmt.Errorf("mismatch number of scan values: %d != %d", m, n)
 	}
 	value, ok := values[0].(*sql.NullInt64)
@@ -83,6 +99,15 @@ func (u *User) assignValues(values ...interface{}) error {
 		return fmt.Errorf("unexpected type %T for field IsAdmin", values[5])
 	} else if value.Valid {
 		u.IsAdmin = value.Bool
+	}
+	values = values[6:]
+	if len(values) == len(user.ForeignKeys) {
+		if value, ok := values[0].(*sql.NullInt64); !ok {
+			return fmt.Errorf("unexpected type %T for edge-field event_liker_id", value)
+		} else if value.Valid {
+			u.event_liker_id = new(int)
+			*u.event_liker_id = int(value.Int64)
+		}
 	}
 	return nil
 }

--- a/ent/user/user.go
+++ b/ent/user/user.go
@@ -42,7 +42,7 @@ const (
 	EventsColumn = "owner_id"
 )
 
-// Columns holds all SQL columns are user fields.
+// Columns holds all SQL columns for user fields.
 var Columns = []string{
 	FieldID,
 	FieldName,
@@ -51,6 +51,11 @@ var Columns = []string{
 	FieldSessionToken,
 	FieldIsActivated,
 	FieldIsAdmin,
+}
+
+// ForeignKeys holds the SQL foreign-keys that are owned by the User type.
+var ForeignKeys = []string{
+	"event_liker_id",
 }
 
 var (

--- a/ent/user_create.go
+++ b/ent/user_create.go
@@ -168,8 +168,8 @@ func (uc *UserCreate) SaveX(ctx context.Context) *User {
 
 func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 	var (
-		u    = &User{config: uc.config}
-		spec = &sqlgraph.CreateSpec{
+		u     = &User{config: uc.config}
+		_spec = &sqlgraph.CreateSpec{
 			Table: user.Table,
 			ID: &sqlgraph.FieldSpec{
 				Type:   field.TypeInt,
@@ -178,7 +178,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		}
 	)
 	if value := uc.Name; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldName,
@@ -186,7 +186,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		u.Name = *value
 	}
 	if value := uc.OAuthID; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldOAuthID,
@@ -194,7 +194,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		u.OAuthID = *value
 	}
 	if value := uc.PhotoURL; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldPhotoURL,
@@ -202,7 +202,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		u.PhotoURL = *value
 	}
 	if value := uc.SessionToken; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldSessionToken,
@@ -210,7 +210,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		u.SessionToken = *value
 	}
 	if value := uc.IsActivated; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: user.FieldIsActivated,
@@ -218,7 +218,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		u.IsActivated = *value
 	}
 	if value := uc.IsAdmin; value != nil {
-		spec.Fields = append(spec.Fields, &sqlgraph.FieldSpec{
+		_spec.Fields = append(_spec.Fields, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: user.FieldIsAdmin,
@@ -242,7 +242,7 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := uc.events; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -261,15 +261,15 @@ func (uc *UserCreate) sqlSave(ctx context.Context) (*User, error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges = append(spec.Edges, edge)
+		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if err := sqlgraph.CreateNode(ctx, uc.driver, spec); err != nil {
+	if err := sqlgraph.CreateNode(ctx, uc.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
 		return nil, err
 	}
-	id := spec.ID.Value.(int64)
+	id := _spec.ID.Value.(int64)
 	u.ID = int(id)
 	return u, nil
 }

--- a/ent/user_delete.go
+++ b/ent/user_delete.go
@@ -39,7 +39,7 @@ func (ud *UserDelete) ExecX(ctx context.Context) int {
 }
 
 func (ud *UserDelete) sqlExec(ctx context.Context) (int, error) {
-	spec := &sqlgraph.DeleteSpec{
+	_spec := &sqlgraph.DeleteSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table: user.Table,
 			ID: &sqlgraph.FieldSpec{
@@ -49,13 +49,13 @@ func (ud *UserDelete) sqlExec(ctx context.Context) (int, error) {
 		},
 	}
 	if ps := ud.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
-	return sqlgraph.DeleteNodes(ctx, ud.driver, spec)
+	return sqlgraph.DeleteNodes(ctx, ud.driver, _spec)
 }
 
 // UserDeleteOne is the builder for deleting a single User entity.

--- a/ent/user_update.go
+++ b/ent/user_update.go
@@ -217,7 +217,7 @@ func (uu *UserUpdate) ExecX(ctx context.Context) {
 }
 
 func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   user.Table,
 			Columns: user.Columns,
@@ -228,48 +228,48 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		},
 	}
 	if ps := uu.predicates; len(ps) > 0 {
-		spec.Predicate = func(selector *sql.Selector) {
+		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
 				ps[i](selector)
 			}
 		}
 	}
 	if value := uu.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldName,
 		})
 	}
 	if value := uu.PhotoURL; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldPhotoURL,
 		})
 	}
 	if value := uu.SessionToken; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldSessionToken,
 		})
 	}
 	if uu.clearSessionToken {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: user.FieldSessionToken,
 		})
 	}
 	if value := uu.IsActivated; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: user.FieldIsActivated,
 		})
 	}
 	if value := uu.IsAdmin; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: user.FieldIsAdmin,
@@ -292,7 +292,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := uu.jobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -311,7 +311,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := uu.removedEvents; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -330,7 +330,7 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := uu.events; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -349,9 +349,9 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if n, err = sqlgraph.UpdateNodes(ctx, uu.driver, spec); err != nil {
+	if n, err = sqlgraph.UpdateNodes(ctx, uu.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}
@@ -556,7 +556,7 @@ func (uuo *UserUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (u *User, err error) {
-	spec := &sqlgraph.UpdateSpec{
+	_spec := &sqlgraph.UpdateSpec{
 		Node: &sqlgraph.NodeSpec{
 			Table:   user.Table,
 			Columns: user.Columns,
@@ -568,41 +568,41 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (u *User, err error) {
 		},
 	}
 	if value := uuo.Name; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldName,
 		})
 	}
 	if value := uuo.PhotoURL; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldPhotoURL,
 		})
 	}
 	if value := uuo.SessionToken; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Value:  *value,
 			Column: user.FieldSessionToken,
 		})
 	}
 	if uuo.clearSessionToken {
-		spec.Fields.Clear = append(spec.Fields.Clear, &sqlgraph.FieldSpec{
+		_spec.Fields.Clear = append(_spec.Fields.Clear, &sqlgraph.FieldSpec{
 			Type:   field.TypeString,
 			Column: user.FieldSessionToken,
 		})
 	}
 	if value := uuo.IsActivated; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: user.FieldIsActivated,
 		})
 	}
 	if value := uuo.IsAdmin; value != nil {
-		spec.Fields.Set = append(spec.Fields.Set, &sqlgraph.FieldSpec{
+		_spec.Fields.Set = append(_spec.Fields.Set, &sqlgraph.FieldSpec{
 			Type:   field.TypeBool,
 			Value:  *value,
 			Column: user.FieldIsAdmin,
@@ -625,7 +625,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (u *User, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := uuo.jobs; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -644,7 +644,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (u *User, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if nodes := uuo.removedEvents; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -663,7 +663,7 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (u *User, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Clear = append(spec.Edges.Clear, edge)
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := uuo.events; len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -682,12 +682,12 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (u *User, err error) {
 		for k, _ := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
-		spec.Edges.Add = append(spec.Edges.Add, edge)
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	u = &User{config: uuo.config}
-	spec.Assign = u.assignValues
-	spec.ScanValues = u.scanValues()
-	if err = sqlgraph.UpdateNode(ctx, uuo.driver, spec); err != nil {
+	_spec.Assign = u.assignValues
+	_spec.ScanValues = u.scanValues()
+	if err = sqlgraph.UpdateNode(ctx, uuo.driver, _spec); err != nil {
 		if cerr, ok := isSQLConstraintError(err); ok {
 			err = cerr
 		}

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -101,6 +101,7 @@ type ComplexityRoot struct {
 		Next         func(childComplexity int) int
 		Owner        func(childComplexity int) int
 		Prev         func(childComplexity int) int
+		Staged       func(childComplexity int) int
 		Tags         func(childComplexity int, input *models.Filter) int
 		Tasks        func(childComplexity int, input *models.Filter) int
 	}
@@ -134,6 +135,7 @@ type ComplexityRoot struct {
 		FailCredential          func(childComplexity int, input *models.FailCredentialRequest) int
 		LikeEvent               func(childComplexity int, input *models.LikeEventRequest) int
 		MakeAdmin               func(childComplexity int, input *models.MakeAdminRequest) int
+		QueueJob                func(childComplexity int, input *models.QueueJobRequest) int
 		RemoveAdmin             func(childComplexity int, input *models.RemoveAdminRequest) int
 		RemoveTagFromJob        func(childComplexity int, input *models.RemoveTagRequest) int
 		RemoveTagFromTarget     func(childComplexity int, input *models.RemoveTagRequest) int
@@ -258,6 +260,7 @@ type LinkResolver interface {
 type MutationResolver interface {
 	FailCredential(ctx context.Context, input *models.FailCredentialRequest) (*ent.Credential, error)
 	CreateJob(ctx context.Context, input *models.CreateJobRequest) (*ent.Job, error)
+	QueueJob(ctx context.Context, input *models.QueueJobRequest) (*ent.Job, error)
 	CreateTag(ctx context.Context, input *models.CreateTagRequest) (*ent.Tag, error)
 	ApplyTagToTask(ctx context.Context, input *models.ApplyTagRequest) (*ent.Task, error)
 	ApplyTagToTargets(ctx context.Context, input *models.ApplyTagToTargetsRequest) ([]*ent.Target, error)
@@ -605,6 +608,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Job.Prev(childComplexity), true
 
+	case "Job.staged":
+		if e.complexity.Job.Staged == nil {
+			break
+		}
+
+		return e.complexity.Job.Staged(childComplexity), true
+
 	case "Job.tags":
 		if e.complexity.Job.Tags == nil {
 			break
@@ -903,6 +913,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.MakeAdmin(childComplexity, args["input"].(*models.MakeAdminRequest)), true
+
+	case "Mutation.queueJob":
+		if e.complexity.Mutation.QueueJob == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_queueJob_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.QueueJob(childComplexity, args["input"].(*models.QueueJobRequest)), true
 
 	case "Mutation.removeAdmin":
 		if e.complexity.Mutation.RemoveAdmin == nil {
@@ -1677,6 +1699,7 @@ type Job @goModel(model: "github.com/kcarretto/paragon/ent.Job") {
   name: String
   creationTime: Time
   content: String
+  staged: Boolean
 
   tasks(input: Filter): [Task]
   tags(input: Filter): [Tag]
@@ -1762,6 +1785,7 @@ input CreateJobRequest {
   name: String!
   content: String!
   sessionID: String
+  stage: Boolean
 
   targets: [ID!]
   tags: [ID!]
@@ -1879,12 +1903,17 @@ input LikeEventRequest {
   id: ID!
 }
 
+input QueueJobRequest {
+  id: ID!
+}
+
 type Mutation {
   # Credential Mutations
   failCredential(input: FailCredentialRequest): Credential!
 
   # Job Mutations
   createJob(input: CreateJobRequest): Job!
+  queueJob(input: QueueJobRequest): Job!
 
   # Tag Mutations
   createTag(input: CreateTagRequest): Tag!
@@ -2293,6 +2322,20 @@ func (ec *executionContext) field_Mutation_makeAdmin_args(ctx context.Context, r
 	var arg0 *models.MakeAdminRequest
 	if tmp, ok := rawArgs["input"]; ok {
 		arg0, err = ec.unmarshalOMakeAdminRequest2ᚖgithubᚗcomᚋkcarrettoᚋparagonᚋgraphqlᚋmodelsᚐMakeAdminRequest(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_queueJob_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *models.QueueJobRequest
+	if tmp, ok := rawArgs["input"]; ok {
+		arg0, err = ec.unmarshalOQueueJobRequest2ᚖgithubᚗcomᚋkcarrettoᚋparagonᚋgraphqlᚋmodelsᚐQueueJobRequest(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -3975,6 +4018,40 @@ func (ec *executionContext) _Job_content(ctx context.Context, field graphql.Coll
 	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Job_staged(ctx context.Context, field graphql.CollectedField, obj *ent.Job) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Job",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Staged, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Job_tasks(ctx context.Context, field graphql.CollectedField, obj *ent.Job) (ret graphql.Marshaler) {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() {
@@ -4403,6 +4480,50 @@ func (ec *executionContext) _Mutation_createJob(ctx context.Context, field graph
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.Mutation().CreateJob(rctx, args["input"].(*models.CreateJobRequest))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*ent.Job)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNJob2ᚖgithubᚗcomᚋkcarrettoᚋparagonᚋentᚐJob(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_queueJob(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+		ec.Tracer.EndFieldExecution(ctx)
+	}()
+	rctx := &graphql.ResolverContext{
+		Object:   "Mutation",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Mutation_queueJob_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	rctx.Args = args
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().QueueJob(rctx, args["input"].(*models.QueueJobRequest))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -9252,6 +9373,12 @@ func (ec *executionContext) unmarshalInputCreateJobRequest(ctx context.Context, 
 			if err != nil {
 				return it, err
 			}
+		case "stage":
+			var err error
+			it.Stage, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "targets":
 			var err error
 			it.Targets, err = ec.unmarshalOID2ᚕintᚄ(ctx, v)
@@ -9476,6 +9603,24 @@ func (ec *executionContext) unmarshalInputLikeEventRequest(ctx context.Context, 
 
 func (ec *executionContext) unmarshalInputMakeAdminRequest(ctx context.Context, obj interface{}) (models.MakeAdminRequest, error) {
 	var it models.MakeAdminRequest
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "id":
+			var err error
+			it.ID, err = ec.unmarshalNID2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputQueueJobRequest(ctx context.Context, obj interface{}) (models.QueueJobRequest, error) {
+	var it models.QueueJobRequest
 	var asMap = obj.(map[string]interface{})
 
 	for k, v := range asMap {
@@ -9973,6 +10118,8 @@ func (ec *executionContext) _Job(ctx context.Context, sel ast.SelectionSet, obj 
 			out.Values[i] = ec._Job_creationTime(ctx, field, obj)
 		case "content":
 			out.Values[i] = ec._Job_content(ctx, field, obj)
+		case "staged":
+			out.Values[i] = ec._Job_staged(ctx, field, obj)
 		case "tasks":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -10105,6 +10252,11 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			}
 		case "createJob":
 			out.Values[i] = ec._Mutation_createJob(ctx, field)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "queueJob":
+			out.Values[i] = ec._Mutation_queueJob(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -12008,6 +12160,18 @@ func (ec *executionContext) unmarshalOMakeAdminRequest2ᚖgithubᚗcomᚋkcarret
 		return nil, nil
 	}
 	res, err := ec.unmarshalOMakeAdminRequest2githubᚗcomᚋkcarrettoᚋparagonᚋgraphqlᚋmodelsᚐMakeAdminRequest(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) unmarshalOQueueJobRequest2githubᚗcomᚋkcarrettoᚋparagonᚋgraphqlᚋmodelsᚐQueueJobRequest(ctx context.Context, v interface{}) (models.QueueJobRequest, error) {
+	return ec.unmarshalInputQueueJobRequest(ctx, v)
+}
+
+func (ec *executionContext) unmarshalOQueueJobRequest2ᚖgithubᚗcomᚋkcarrettoᚋparagonᚋgraphqlᚋmodelsᚐQueueJobRequest(ctx context.Context, v interface{}) (*models.QueueJobRequest, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOQueueJobRequest2githubᚗcomᚋkcarrettoᚋparagonᚋgraphqlᚋmodelsᚐQueueJobRequest(ctx, v)
 	return &res, err
 }
 

--- a/graphql/models/generated.go
+++ b/graphql/models/generated.go
@@ -54,6 +54,7 @@ type CreateJobRequest struct {
 	Name      string  `json:"name"`
 	Content   string  `json:"content"`
 	SessionID *string `json:"sessionID"`
+	Stage     *bool   `json:"stage"`
 	Targets   []int   `json:"targets"`
 	Tags      []int   `json:"tags"`
 	Prev      *int    `json:"prev"`
@@ -102,6 +103,10 @@ type LikeEventRequest struct {
 }
 
 type MakeAdminRequest struct {
+	ID int `json:"id"`
+}
+
+type QueueJobRequest struct {
 	ID int `json:"id"`
 }
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -63,6 +63,7 @@ type Job @goModel(model: "github.com/kcarretto/paragon/ent.Job") {
   name: String
   creationTime: Time
   content: String
+  staged: Boolean
 
   tasks(input: Filter): [Task]
   tags(input: Filter): [Tag]
@@ -148,6 +149,7 @@ input CreateJobRequest {
   name: String!
   content: String!
   sessionID: String
+  stage: Boolean
 
   targets: [ID!]
   tags: [ID!]
@@ -265,12 +267,17 @@ input LikeEventRequest {
   id: ID!
 }
 
+input QueueJobRequest {
+  id: ID!
+}
+
 type Mutation {
   # Credential Mutations
   failCredential(input: FailCredentialRequest): Credential!
 
   # Job Mutations
   createJob(input: CreateJobRequest): Job!
+  queueJob(input: QueueJobRequest): Job!
 
   # Tag Mutations
   createTag(input: CreateTagRequest): Tag!

--- a/www/src/graphql/models.tsx
+++ b/www/src/graphql/models.tsx
@@ -60,6 +60,7 @@ export type CreateJobRequest = {
   name: Scalars['String'],
   content: Scalars['String'],
   sessionID?: Maybe<Scalars['String']>,
+  stage?: Maybe<Scalars['Boolean']>,
   targets?: Maybe<Array<Scalars['ID']>>,
   tags?: Maybe<Array<Scalars['ID']>>,
   prev?: Maybe<Scalars['ID']>,
@@ -160,6 +161,7 @@ export type Job = {
   name?: Maybe<Scalars['String']>,
   creationTime?: Maybe<Scalars['Time']>,
   content?: Maybe<Scalars['String']>,
+  staged?: Maybe<Scalars['Boolean']>,
   tasks?: Maybe<Array<Maybe<Task>>>,
   tags?: Maybe<Array<Maybe<Tag>>>,
   next?: Maybe<Job>,
@@ -200,6 +202,7 @@ export type Mutation = {
   failCredential: Credential,
   /** Job Mutations */
   createJob: Job,
+  queueJob: Job,
   /** Tag Mutations */
   createTag: Tag,
   applyTagToTask: Task,
@@ -242,6 +245,11 @@ export type MutationFailCredentialArgs = {
 
 export type MutationCreateJobArgs = {
   input?: Maybe<CreateJobRequest>
+};
+
+
+export type MutationQueueJobArgs = {
+  input?: Maybe<QueueJobRequest>
 };
 
 
@@ -492,6 +500,10 @@ export type QueryEventArgs = {
 
 export type QueryEventsArgs = {
   input?: Maybe<Filter>
+};
+
+export type QueueJobRequest = {
+  id: Scalars['ID'],
 };
 
 export type RemoveAdminRequest = {


### PR DESCRIPTION
this PR does the following:

- adds staged bool to job ent
- adds new mutation `queueJob`, if passed unstaged job will error
- adds new optional field "stage" to `createJob`
- filters tasks whose job is staged from `claimTasks`
- checks for job to be staged on `submitTaskResult` and `claimTask`