### PR TITLE
Asset drop

### DIFF
--- a/pkg/script/stdlib/assert/operations.go
+++ b/pkg/script/stdlib/assert/operations.go
@@ -21,7 +21,7 @@ func NoError(err starlark.Value) error {
 	if !ok {
 		errString, ok := err.(starlark.String)
 		if !ok {
-			return fmt.Errorf("assertion failed: error is not None")
+			return fmt.Errorf("assertion failed: error is not None: %+v", err)
 		}
 		return fmt.Errorf("assertion failed: error is not None: %v", errString)
 	}

--- a/pkg/script/stdlib/assets/assets.go
+++ b/pkg/script/stdlib/assets/assets.go
@@ -21,6 +21,7 @@ func (env *Environment) Library(options ...func(*Environment)) script.Library {
 
 	return script.Library{
 		"openFile": script.Func(env.openFile),
+		"drop":     script.Func(env.drop),
 		// "exec":     script.Func(env.exec),
 		// "openFile": script.Func(env.openFile),
 	}

--- a/pkg/script/stdlib/assets/assets.go
+++ b/pkg/script/stdlib/assets/assets.go
@@ -30,18 +30,3 @@ func (env *Environment) Library(options ...func(*Environment)) script.Library {
 func (env *Environment) Include(options ...func(*Environment)) script.Option {
 	return script.WithLibrary("assets", (*Environment).Library(env, options...))
 }
-
-// package assets
-
-// import (
-// 	"net/http"
-
-// 	"github.com/kcarretto/paragon/pkg/script"
-// )
-
-// // Import the assets library to enable scripts to load assets from the provided filesystem.
-// func Import(assets http.FileSystem) script.Library {
-// 	return script.Library{
-// 		"load": Load(assets),
-// 	}
-// }

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -1,10 +1,14 @@
 package assets
 
 import (
+	"errors"
 	"fmt"
+	"math/rand"
+	"strconv"
 
 	"github.com/kcarretto/paragon/pkg/script"
 	"github.com/kcarretto/paragon/pkg/script/stdlib/file"
+	"github.com/kcarretto/paragon/pkg/script/stdlib/sys"
 )
 
 // OpenFile that was packed into the compiled binary. The resulting file does not support many
@@ -36,6 +40,59 @@ func (env *Environment) openFile(parser script.ArgParser) (script.Retval, error)
 	if err != nil {
 		return nil, err
 	}
-	retVal, retErr := (*Environment).OpenFile(env, path)
+	retVal, retErr := env.OpenFile(path)
 	return script.WithError(retVal, retErr), nil
+}
+
+// Drop will take a given file, copy it to disk, optionaly set the permissions move it to a given
+// destination, and clean up the temp file created. The default perms are '0755'.
+//
+//go:generate go run ../gendoc.go -lib assets -func drop -param f@File -param dstPath@String -param perms@String -retval err@Error -doc "Drop will take a given file, copy it to disk, optionaly set the permissions move it to a given destination, and clean up the temp file created. The default perms are '0755'."
+//
+// @callable:	assets.drop
+// @param:		f 		@File
+// @param:		dstPath @String
+// @param:		perms 	@String
+// @retval:		err 	@Error
+//
+// @usage:		f, err = assets.drop(bot, "/path/to/bot_dst", "0755")
+func (env *Environment) Drop(f file.Type, dstPath, perms string) error {
+	tmpFile, err := sys.OpenFile(strconv.Itoa(rand.Int()))
+	if err != nil {
+		return err
+	}
+	err = file.Copy(f, tmpFile)
+	if err != nil {
+		return err
+	}
+	err = file.Chmod(tmpFile, perms)
+	if err != nil {
+		return err
+	}
+	err = file.Move(tmpFile, dstPath)
+	if err != nil {
+		return err
+	}
+	err = file.Remove(tmpFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (env *Environment) drop(parser script.ArgParser) (script.Retval, error) {
+	f, err := file.ParseParam(parser, 0)
+	if err != nil {
+		return nil, err
+	}
+	dstPath, err := parser.GetString(1)
+	if err != nil {
+		return nil, err
+	}
+	perms, err := parser.GetString(2)
+	if errors.Is(err, script.ErrMissingArg) {
+		perms = "0644"
+	}
+	retErr := env.Drop(f, dstPath, perms)
+	return script.WithError(nil, retErr), nil
 }

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -66,7 +66,7 @@ func (env *Environment) Drop(f file.Type, dstPath, perms string) (err error) {
 			return
 		}
 		if removeErr := file.Remove(tmpFile); removeErr != nil {
-			err = fmt.Errorf("failed to remove file after move failure: %w: %w", err, removeErr)
+			err = fmt.Errorf("failed to remove file after move failure: %w: %v", err, removeErr)
 		}
 	}()
 	err = file.Copy(f, tmpFile)

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -56,11 +56,19 @@ func (env *Environment) openFile(parser script.ArgParser) (script.Retval, error)
 // @retval:		err 	@Error
 //
 // @usage:		f, err = assets.drop(bot, "/path/to/bot_dst", "0755")
-func (env *Environment) Drop(f file.Type, dstPath, perms string) error {
+func (env *Environment) Drop(f file.Type, dstPath, perms string) (err error) {
 	tmpFile, err := sys.OpenFile(strconv.Itoa(rand.Int()))
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		if removeErr := file.Remove(tmpFile); removeErr != nil {
+			err = fmt.Errorf("failed to remove file after move failure: %w: %w", err, removeErr)
+		}
+	}()
 	err = file.Copy(f, tmpFile)
 	if err != nil {
 		return err

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -73,10 +73,6 @@ func (env *Environment) Drop(f file.Type, dstPath, perms string) error {
 	if err != nil {
 		return err
 	}
-	err = file.Remove(tmpFile)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -61,7 +61,7 @@ func (env *Environment) Drop(f file.Type, dstPath, perms string) error {
 	if err != nil {
 		return err
 	}
-	err = file.Copy(f, tmpFile)
+	err = file.Copy(tmpFile, f)
 	if err != nil {
 		return err
 	}

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -87,7 +87,7 @@ func (env *Environment) drop(parser script.ArgParser) (script.Retval, error) {
 	}
 	perms, err := parser.GetString(2)
 	if errors.Is(err, script.ErrMissingArg) {
-		perms = "0644"
+		perms = "0755"
 	}
 	retErr := env.Drop(f, dstPath, perms)
 	return retErr, nil

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -94,5 +94,5 @@ func (env *Environment) drop(parser script.ArgParser) (script.Retval, error) {
 		perms = "0644"
 	}
 	retErr := env.Drop(f, dstPath, perms)
-	return script.WithError(nil, retErr), nil
+	return retErr, nil
 }

--- a/pkg/script/stdlib/assets/operations.go
+++ b/pkg/script/stdlib/assets/operations.go
@@ -61,7 +61,7 @@ func (env *Environment) Drop(f file.Type, dstPath, perms string) error {
 	if err != nil {
 		return err
 	}
-	err = file.Copy(tmpFile, f)
+	err = file.Copy(f, tmpFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/script/stdlib/file/operations.go
+++ b/pkg/script/stdlib/file/operations.go
@@ -25,7 +25,7 @@ func Move(file Type, dstPath string) error {
 }
 
 func move(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func Close(file Type) {
 }
 
 func fclose(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func Name(file Type) string {
 }
 
 func name(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func Content(file Type) (string, error) {
 }
 
 func content(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func Write(file Type, content string) error {
 }
 
 func write(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -155,11 +155,11 @@ func Copy(src Type, dst Type) error {
 }
 
 func copy(parser script.ArgParser) (script.Retval, error) {
-	src, err := parseFileParam(parser, 0)
+	src, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
-	dst, err := parseFileParam(parser, 1)
+	dst, err := ParseParam(parser, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func Remove(file Type) error {
 }
 
 func remove(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func Chown(file Type, username, group string) error {
 }
 
 func chown(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func Chmod(file Type, mode string) error {
 }
 
 func chmod(parser script.ArgParser) (script.Retval, error) {
-	f, err := parseFileParam(parser, 0)
+	f, err := ParseParam(parser, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/script/stdlib/file/starlark.go
+++ b/pkg/script/stdlib/file/starlark.go
@@ -114,8 +114,8 @@ func (f Type) Hash() (uint32, error) {
 	return 0, fmt.Errorf("file type is unhashable")
 }
 
-// parseFileParam from starlark input
-func parseFileParam(parser script.ArgParser, index int) (Type, error) {
+// ParseParam from starlark input
+func ParseParam(parser script.ArgParser, index int) (Type, error) {
 	val, err := parser.GetParam(index)
 	if err != nil {
 		return Type{}, err

--- a/www/src/config/renegade/spec.json
+++ b/www/src/config/renegade/spec.json
@@ -225,6 +225,16 @@
             { "name": "f", "type": "File" },
             { "name": "err", "type": "Error" }
           ]
+        },
+        {
+          "name": "drop",
+          "doc": "Drop will take a given file, copy it to disk, optionaly set the permissions move it to a given destination, and clean up the temp file created. The default perms are '0755'.",
+          "params": [
+            { "name": "f", "type": "File" },
+            { "name": "dstPath", "type": "String" },
+            { "name": "perms", "type": "String" }
+          ],
+          "retvals": [{ "name": "err", "type": "Error" }]
         }
       ]
     },


### PR DESCRIPTION
adds the `assets.drop` function for the dropper. This provides a much needed abstraction. On how we drop files in the dropper. This function will safely replace the `dstPath` with the passed file. Also allows for optional parameters