### PR TITLE
Ignore ipv6 addresses at agent

### DIFF
--- a/pkg/agent/metadata.go
+++ b/pkg/agent/metadata.go
@@ -78,7 +78,7 @@ func (agent *Agent) collectMetadata() {
 			agent.Log.Error("Failed to collect machine primary IP", zap.Error(err))
 			continue
 		}
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.To4() == nil {
 			continue
 		}
 		agent.Metadata.PrimaryIP = ip.String()


### PR DESCRIPTION
# Description

Ignores ipv6 addresses when determining a primaryIP at the Agent. 

Fixes #287 

Skips ipv6 addresses in pkg/agent/metadata.go determined via the IP.to4() method (https://golang.org/src/net/ip.go?s=5275:5296#L179)

# Test Plan

What?
