### PR TITLE
Target on MACs rather than UUID

### DIFF
--- a/ent/schema/target.go
+++ b/ent/schema/target.go
@@ -42,7 +42,6 @@ func (Target) Fields() []ent.Field {
 			Comment("The IP Address for the primary interface of the Target"),
 		field.String("MachineUUID").
 			MaxLen(250).
-			Unique().
 			Optional().
 			Comment("The machine UUID of the Target"),
 		field.String("PublicIP").

--- a/graphql/resolve/generated.go
+++ b/graphql/resolve/generated.go
@@ -685,10 +685,10 @@ func (r *mutationResolver) ClaimTasks(ctx context.Context, input *models.ClaimTa
 	if os.Getenv("PG_KS_MachineUUID") != "" {
 		input.MachineUUID = nil
 	}
-	// check for valid machineuuid
-	if input.MachineUUID != nil && *input.MachineUUID != "" {
+	// check for valid PrimaryMac
+	if input.PrimaryMac != nil && *input.PrimaryMac != "" {
 		targetEnt, err = r.Graph.Target.Query().
-			Where(target.MachineUUID(*input.MachineUUID)).
+			Where(target.PrimaryMAC(*input.PrimaryMac)).
 			Only(ctx)
 	}
 


### PR DESCRIPTION
# Description
Targeting on UUIDs has been problematic in environments where VMs are duplicated w/o sysprep (see: all of them)

Fixes #290 

Targets on PrimaryMAC, rather than MachineUUID. We've found PrimaryMAC to be a better indicator of a unique host. A more ideal future solution would be to combine MAC+UUID, but this should work for now..

# Test Plan

Tested live via hotfix in production during SECCDC regionals.
