### PR TITLE
Correctly format taskID for agent exec

### DIFF
--- a/cmd/agent/executor.go
+++ b/cmd/agent/executor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/kcarretto/paragon/pkg/agent/transport"
@@ -21,7 +22,7 @@ type Executor struct{}
 // ExecuteTask runs a renegade script.
 func (exec Executor) ExecuteTask(ctx context.Context, output io.Writer, task *transport.Task) error {
 	code := script.New(
-		string(task.GetId()),
+		fmt.Sprint(task.GetId()),
 		bytes.NewBufferString(task.Content),
 		script.WithOutput(output),
 		sys.Include(),


### PR DESCRIPTION
# Description

Before: The execute function's stringified task ID only returns a rune (not a text int)
After: The task ID is properly converted to a string representing the integer via fmt.Sprint

Fixes # (issue)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

# Test Plan

Describe how you've tested these changes.
